### PR TITLE
Hopefully fixed #4

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/App.config
+++ b/src/Akka.Persistence.MongoDb.Tests/App.config
@@ -5,6 +5,6 @@
          The directory for an instance is created in C:\data and has db as prefix.
          For example, C:\data\db_27018 where 27018 is the port number.
     -->
-    <add key="DatabaseDirectory" value="C:\data\db"/>
+    <add key="DatabaseDirectory" value="D:\data\db"/>
   </appSettings>
 </configuration>

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -21,6 +21,14 @@ namespace Akka.Persistence.MongoDb.Tests
                     collection = ""EventJournal""
                 }
             }
+            snapshot-store {
+                plugin = ""akka.persistence.snapshot-store.mongodb""
+                mongodb {
+                    class = ""Akka.Persistence.MongoDb.Snapshot.MongoDbSnapshotStore, Akka.Persistence.MongoDb""
+                    connection-string = ""<ConnectionString>""
+                    collection = ""SnapshotStore""
+                }
+            }
         }";
 
         public MongoDbJournalSpec() : base(CreateSpecConfig(), "MongoDbJournalSpec")

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -1,11 +1,15 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using Akka.Persistence.TestKit.Journal;
 using Mongo2Go;
+using MongoDB.Driver;
 
 namespace Akka.Persistence.MongoDb.Tests
 {
     public class MongoDbJournalSpec : JournalSpec
     {
+        private static readonly MongoDbRunner Runner = MongoDbRunner.Start(ConfigurationManager.AppSettings[0]);
+
         private static readonly string SpecConfig = @"
         akka.persistence {
             publish-plugin-commands = on
@@ -19,29 +23,25 @@ namespace Akka.Persistence.MongoDb.Tests
             }
         }";
 
-        private static MongoDbRunner _runner;
-
         public MongoDbJournalSpec() : base(CreateSpecConfig(), "MongoDbJournalSpec")
         {
+            AppDomain.CurrentDomain.DomainUnload += (_, __) => Runner.Dispose();
+
             Initialize();
         }
 
         private static string CreateSpecConfig()
         {
-            _runner = MongoDbRunner.Start(ConfigurationManager.AppSettings[0]);
-            return SpecConfig.Replace("<ConnectionString>", _runner.ConnectionString + "akkanet");
+            return SpecConfig.Replace("<ConnectionString>", Runner.ConnectionString + "akkanet");
         }
 
         protected override void Dispose(bool disposing)
         {
+            new MongoClient(Runner.ConnectionString)
+                .GetDatabase("akkanet")
+                .DropCollectionAsync("EventJournal").Wait();
+            
             base.Dispose(disposing);
-
-            try
-            {
-                _runner.Dispose();
-            }
-            catch { }
-            _runner = null;
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -25,7 +25,14 @@ namespace Akka.Persistence.MongoDb.Tests
 
         public MongoDbJournalSpec() : base(CreateSpecConfig(), "MongoDbJournalSpec")
         {
-            AppDomain.CurrentDomain.DomainUnload += (_, __) => Runner.Dispose();
+            AppDomain.CurrentDomain.DomainUnload += (_, __) =>
+            {
+                try
+                {
+                    Runner.Dispose();
+                }
+                catch { }
+            };
 
             Initialize();
         }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
@@ -21,6 +21,14 @@ namespace Akka.Persistence.MongoDb.Tests
                     collection = ""SnapshotStore""
                 }
             }
+            journal {
+                plugin = ""akka.persistence.journal.mongodb""
+                mongodb {
+                    class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                    connection-string = ""<ConnectionString>""
+                    collection = ""EventJournal""
+                }
+            }
         }";
 
 

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
@@ -26,7 +26,15 @@ namespace Akka.Persistence.MongoDb.Tests
 
         public MongoDbSnapshotStoreSpec() : base(CreateSpecConfig(), "MongoDbSnapshotStoreSpec")
         {
-            AppDomain.CurrentDomain.DomainUnload += (_, __) => Runner.Dispose();
+            AppDomain.CurrentDomain.DomainUnload += (_, __) =>
+            {
+                try
+                {
+                    Runner.Dispose();
+                }
+                catch { }
+            };
+
 
             Initialize();
         }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
@@ -1,11 +1,15 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using Akka.Persistence.TestKit.Snapshot;
 using Mongo2Go;
+using MongoDB.Driver;
 
 namespace Akka.Persistence.MongoDb.Tests
 {
     public class MongoDbSnapshotStoreSpec : SnapshotStoreSpec
     {
+        private static readonly MongoDbRunner Runner = MongoDbRunner.Start(ConfigurationManager.AppSettings[0]);
+
         private static readonly string SpecConfig = @"
         akka.persistence {
             publish-plugin-commands = on
@@ -18,29 +22,27 @@ namespace Akka.Persistence.MongoDb.Tests
                 }
             }
         }";
-        private static MongoDbRunner _runner;
+
 
         public MongoDbSnapshotStoreSpec() : base(CreateSpecConfig(), "MongoDbSnapshotStoreSpec")
         {
+            AppDomain.CurrentDomain.DomainUnload += (_, __) => Runner.Dispose();
+
             Initialize();
         }
 
         private static string CreateSpecConfig()
         {
-            _runner = MongoDbRunner.Start(ConfigurationManager.AppSettings[0]);
-            return SpecConfig.Replace("<ConnectionString>", _runner.ConnectionString + "akkanet");
+            return SpecConfig.Replace("<ConnectionString>", Runner.ConnectionString + "akkanet");
         }
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
+            new MongoClient(Runner.ConnectionString)
+                .GetDatabase("akkanet")
+                .DropCollectionAsync("SnapshotStore").Wait();
 
-            try
-            {
-                _runner.Dispose();
-            }
-            catch { }
-            _runner = null;
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.sln
+++ b/src/Akka.Persistence.MongoDb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.MongoDb", "Akka.Persistence.MongoDb\Akka.Persistence.MongoDb.csproj", "{12E044EF-08A2-428B-AAF5-C3D328860C4E}"
 EndProject


### PR DESCRIPTION
Instead of creating a MongoDbRunner per test, we now use only one for all journal and another one for alle snapshot tests.