### PR TITLE
added the ability to auto-upgrade nuget packages

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -154,6 +154,45 @@ module Nuget =
 
 open Nuget
 
+open NuGet.Update
+
+//--------------------------------------------------------------------------------
+// Upgrade nuget package versions for dev and production
+
+let updateNugetPackages _ =
+  printfn "Updating NuGet dependencies"
+
+  let getConfigFile preRelease =
+    match preRelease with
+    | true -> "src/.nuget/NuGet.Dev.Config" 
+    | false -> "src/.nuget/NuGet.Config" 
+
+  let getPackages project =
+    match project with
+    | "Akka.Persistence.MongoDb" -> ["Akka.Persistence"; "Newtonsoft.Json";]
+    | "Akka.Persistence.MongoDb.Tests" -> ["Akka.Persistence"; "Akka.Persistence.TestKit"; "Newtonsoft.Json";]
+    | _ -> []
+
+  for projectFile in !! "src/**/*.csproj" do
+    printfn "Updating packages for %s" projectFile
+    let project = Path.GetFileNameWithoutExtension projectFile
+    let projectDir = Path.GetDirectoryName projectFile
+    let config = projectDir @@ "packages.config"
+
+    NugetUpdate
+        (fun p ->
+                { p with
+                    ConfigFile = Some (getConfigFile isPreRelease)
+                    Prerelease = true
+                    ToolPath = nugetExe
+                    RepositoryPath = "src/Packages"
+                    Ids = getPackages project
+                    }) config
+
+Target "UpdateDependencies" <| fun _ ->
+    printfn "Invoking updateNugetPackages"
+    updateNugetPackages()
+
 //--------------------------------------------------------------------------------
 // Clean nuget directory
 
@@ -383,7 +422,7 @@ Target "HelpDocs" <| fun _ ->
 //--------------------------------------------------------------------------------
 
 // build dependencies
-"Clean" ==> "AssemblyInfo" ==> "RestorePackages" ==> "Build" ==> "CopyOutput" ==> "BuildRelease"
+"Clean" ==> "AssemblyInfo" ==> "RestorePackages" ==> "UpdateDependencies" ==> "Build" ==> "CopyOutput" ==> "BuildRelease"
 
 // tests dependencies
 "CleanTests" ==> "RunTests"

--- a/src/.nuget/NuGet.Dev.Config
+++ b/src/.nuget/NuGet.Dev.Config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <packageSources>
+    <add key="NuGet official" value="https://www.nuget.org/api/v2/" /> <!-- Official package source  -->
+    <add key="Akka.NET Nightly Build" value="https://www.myget.org/F/akkadotnet/api/v2" /> <!-- Nightly package source -->
+  </packageSources>
+</configuration>

--- a/src/Akka.Persistence.MongoDb.sln
+++ b/src/Akka.Persistence.MongoDb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.MongoDb", "Akka.Persistence.MongoDb\Akka.Persistence.MongoDb.csproj", "{12E044EF-08A2-428B-AAF5-C3D328860C4E}"
 EndProject
@@ -17,6 +17,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{65DAEEC3-80C7-42C5-B0AC-DFC928846EF6}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.Dev.Config = .nuget\NuGet.Dev.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection


### PR DESCRIPTION
Using this for nightly integration builds - anytime the Akka.Persistence or Akka.Persistence.TestKit dlls are upgraded, all Akka.Persistence implementations get rebuilt with the latest version automatically