### PR TITLE
Support at least once delivery snapshot

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -67,22 +67,24 @@
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
     <Reference Include="Akka, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.1.0.7\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.8.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.8\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.1.0.7.18-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka.Persistence, Version=1.0.8.25, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.8.25-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence.TestKit, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.7.18-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
+    <Reference Include="Akka.Persistence.TestKit, Version=1.0.8.25, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.8.25-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.0.7\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.0.8.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.0.8\lib\net45\Akka.TestKit.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.7\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
+    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.8.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.8\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -109,14 +111,16 @@
       <HintPath>..\packages\MongoDB.Driver.2.2.4\lib\net45\MongoDB.Driver.dll</HintPath>
     <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.4\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.4\lib\net45\MongoDB.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.4\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -65,6 +65,32 @@
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.7\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.Persistence, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.7.18-beta\lib\net45\Akka.Persistence.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.Persistence.TestKit, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.TestKit.1.0.7.18-beta\lib\net45\Akka.Persistence.TestKit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.TestKit, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.0.7\lib\net45\Akka.TestKit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.TestKit.Xunit2, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.Xunit2.1.0.7\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.ProtocolBuffers.Serialization, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.Serialization.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers.Serialization, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -81,6 +107,16 @@
     </Reference>
     <Reference Include="MongoDB.Driver, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Driver.2.2.4\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -65,8 +65,10 @@
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
+	</Reference>
     <Reference Include="Akka, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.1.0.7\lib\net45\Akka.dll</HintPath>
+	</Reference>
     <Reference Include="Akka, Version=1.0.8.24, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.1.0.8\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
@@ -109,9 +111,11 @@
     </Reference>
     <Reference Include="MongoDB.Driver, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Driver.2.2.4\lib\net45\MongoDB.Driver.dll</HintPath>
+    </Reference>
     <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
-    <Reference Include="MongoDB.Bson, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
+    </Reference>
+	<Reference Include="MongoDB.Bson, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.2.4\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -169,6 +169,7 @@
     <Compile Include="MongoDbSettingsSpec.cs" />
     <Compile Include="MongoDbSnapshotStoreSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Serializers\AtLeastOnceDeliverySnapshotSerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka.Persistence.MongoDb\Akka.Persistence.MongoDb.csproj">

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -20,8 +20,6 @@ namespace Akka.Persistence.MongoDb.Tests
         private static readonly MongoDbRunner Runner = MongoDbRunner.Start(ConfigurationManager.AppSettings[0]);
         protected override bool SupportsRejectingNonSerializableObjects { get { return false; } }
 
-        protected override bool SupportsRejectingNonSerializableObjects { get; } = false;
-
         private static readonly string SpecConfig = @"
             akka.test.single-expect-default = 3s
             akka.persistence {

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -18,6 +18,7 @@ namespace Akka.Persistence.MongoDb.Tests
     public class MongoDbJournalSpec : JournalSpec
     {
         private static readonly MongoDbRunner Runner = MongoDbRunner.Start(ConfigurationManager.AppSettings[0]);
+        protected override bool SupportsRejectingNonSerializableObjects { get { return false; } }
 
         protected override bool SupportsRejectingNonSerializableObjects { get; } = false;
 
@@ -60,7 +61,7 @@ namespace Akka.Persistence.MongoDb.Tests
             new MongoClient(Runner.ConnectionString)
                 .GetDatabase("akkanet")
                 .DropCollectionAsync("EventJournal").Wait();
-            
+
             base.Dispose(disposing);
         }
     }

--- a/src/Akka.Persistence.MongoDb.Tests/Serializers/AtLeastOnceDeliverySnapshotSerializerTests.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Serializers/AtLeastOnceDeliverySnapshotSerializerTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using MongoDB.Bson;
+using Akka.Persistence.MongoDb.Snapshot.Serializers;
+using MongoDB.Bson.Serialization;
+
+namespace Akka.Persistence.MongoDb.Tests.Serializers
+{
+    public class AtLeastOnceDeliverySnapshotSerializerTests
+    {
+        class TestMessage
+        {
+            public TestMessage(string text)
+            {
+                this.Text = text;
+            }
+            public string Text { get; private set; }
+        }
+
+        static AtLeastOnceDeliverySnapshotSerializerTests()
+        {
+            BsonSerializer.RegisterSerializer<AtLeastOnceDeliverySnapshot>(new AtLeastOnceDeliverySnapshotSerializer());
+            BsonSerializer.RegisterSerializer<UnconfirmedDelivery>(new UnconfirmedDeliverySerializer());
+        }
+
+        [Fact]
+        public void TestEmptySnapshot()
+        {
+            var snapshot = new AtLeastOnceDeliverySnapshot(1, new UnconfirmedDelivery[0]);
+
+            var json = snapshot.ToJson();
+            var expected = "{ '_t' : 'AtLeastOnceDeliverySnapshot', 'CurrentDeliveryId' : NumberLong(1), 'UnconfirmedDeliveries' : { '_t' : 'UnconfirmedDelivery[]', '_v' : [] } }"
+                .Replace("'", "\"");
+            Assert.Equal(expected, json);
+
+            var bson = snapshot.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<AtLeastOnceDeliverySnapshot>(bson);
+            Assert.True(bson.SequenceEqual(rehydrated.ToBson()));
+        }
+
+        [Fact]
+        public void TestSnapshotWithUnconfirmedDelivery()
+        {
+            var snapshot = new AtLeastOnceDeliverySnapshot(1, new[] { new UnconfirmedDelivery(1, Actor.ActorPath.Parse("akka://MySystem/user/test"), new TestMessage("Test message")) });
+
+            var json = snapshot.ToJson();
+            var expected = "{ '_t' : 'AtLeastOnceDeliverySnapshot', 'CurrentDeliveryId' : NumberLong(1), 'UnconfirmedDeliveries' : { '_t' : 'UnconfirmedDelivery[]', '_v' : [{ '_t' : 'UnconfirmedDelivery', 'DeliveryId' : NumberLong(1), 'Destination' : 'akka://MySystem/user/test', 'Message' : { '_t' : 'TestMessage', 'Text' : 'Test message' } }] } }"
+                .Replace("'", "\"");
+            Assert.Equal(expected, json);
+
+            var bson = snapshot.ToBson();
+            var rehydrated = BsonSerializer.Deserialize<AtLeastOnceDeliverySnapshot>(bson);
+            Assert.True(bson.SequenceEqual(rehydrated.ToBson()));
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -40,10 +40,12 @@
       <HintPath>..\packages\Akka.Persistence.1.1.1.28-beta\lib\net45\Akka.Persistence.dll</HintPath>
     <Reference Include="Akka, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.1.0.7\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.8.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.8\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.Persistence, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.Persistence.1.0.7.18-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka.Persistence, Version=1.0.8.25, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.8.25-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -68,12 +70,12 @@
       <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.4\lib\net45\MongoDB.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.4\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -38,6 +38,12 @@
     </Reference>
     <Reference Include="Akka.Persistence, Version=1.1.1.28, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.Persistence.1.1.1.28-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    <Reference Include="Akka, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.0.7\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.Persistence, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Persistence.1.0.7.18-beta\lib\net45\Akka.Persistence.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
@@ -58,6 +64,16 @@
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Driver.Core.2.2.4\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.2.3\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.2.3\lib\net45\MongoDB.Driver.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -38,8 +38,10 @@
     </Reference>
     <Reference Include="Akka.Persistence, Version=1.1.1.28, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.Persistence.1.1.1.28-beta\lib\net45\Akka.Persistence.dll</HintPath>
+    </Reference>
     <Reference Include="Akka, Version=1.0.7.18, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.1.0.7\lib\net45\Akka.dll</HintPath>
+    </Reference>
     <Reference Include="Akka, Version=1.0.8.24, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.1.0.8\lib\net45\Akka.dll</HintPath>
       <Private>True</Private>
@@ -66,6 +68,7 @@
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.2.4.26, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Driver.Core.2.2.4\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    </Reference>
     <Reference Include="MongoDB.Bson, Version=2.2.3.3, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.2.3\lib\net45\MongoDB.Bson.dll</HintPath>
       <Private>True</Private>

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -106,6 +106,8 @@
     <Compile Include="MongoDbPersistenceProvider.cs" />
     <Compile Include="MongoDbSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Snapshot\Serializers\AtLeastOnceDeliverySnapshotSerializer.cs" />
+    <Compile Include="Snapshot\Serializers\UnconfirmedDeliverySerializer.cs" />
     <Compile Include="Snapshot\SnapshotEntry.cs" />
     <Compile Include="Snapshot\MongoDbSnapshotStore.cs" />
   </ItemGroup>

--- a/src/Akka.Persistence.MongoDb/Journal/JournalEntry.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/JournalEntry.cs
@@ -1,10 +1,11 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="JournalEntry.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
 
+﻿using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Akka.Persistence.MongoDb.Journal
@@ -32,5 +33,16 @@ namespace Akka.Persistence.MongoDb.Journal
 
         [BsonElement("Manifest")]
         public string Manifest { get; set; }
+    }
+
+
+    public class JournalCommit
+    {
+        [BsonId]
+        public ObjectId Id { get; set; }
+
+        [BsonElement("Entries")]
+        public JournalEntry[] Entries { get; set; }
+
     }
 }

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -123,7 +123,11 @@ namespace Akka.Persistence.MongoDb.Journal
                 var persistentMessages = ((IImmutableList<IPersistentRepresentation>)message.Payload).ToArray();
 
                 var journalEntries = persistentMessages.Select(ToJournalEntry).ToList();
-                await _journalCollection.Value.InsertManyAsync(journalEntries);
+
+                await _journalCollection.Value.InsertManyAsync(journalEntries, new InsertManyOptions()
+                {
+                    IsOrdered = true
+                });
             });
 
             await SetHighSequenceId(messageList);

--- a/src/Akka.Persistence.MongoDb/MongoDbPersistence.cs
+++ b/src/Akka.Persistence.MongoDb/MongoDbPersistence.cs
@@ -8,6 +8,7 @@
 using System;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Persistence.MongoDb.Snapshot.Serializers;
 
 namespace Akka.Persistence.MongoDb
 {
@@ -47,6 +48,10 @@ namespace Akka.Persistence.MongoDb
 
             // Initialize fallback configuration defaults
             system.Settings.InjectTopLevelFallback(DefaultConfiguration());
+
+            // Add Serializer
+            MongoDB.Bson.Serialization.BsonSerializer.RegisterSerializer<Akka.Persistence.AtLeastOnceDeliverySnapshot>(new AtLeastOnceDeliverySnapshotSerializer());
+            MongoDB.Bson.Serialization.BsonSerializer.RegisterSerializer<UnconfirmedDelivery>(new UnconfirmedDeliverySerializer());
 
             // Read config
             var journalConfig = system.Settings.Config.GetConfig("akka.persistence.journal.mongodb");

--- a/src/Akka.Persistence.MongoDb/Snapshot/Serializers/AtLeastOnceDeliverySnapshotSerializer.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/Serializers/AtLeastOnceDeliverySnapshotSerializer.cs
@@ -1,0 +1,53 @@
+﻿using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Akka.Persistence.MongoDb.Snapshot.Serializers
+{
+    public class AtLeastOnceDeliverySnapshotSerializer : SerializerBase<AtLeastOnceDeliverySnapshot>
+    {
+        public override Akka.Persistence.AtLeastOnceDeliverySnapshot Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            var currentBsonType = context.Reader.GetCurrentBsonType();
+
+            if (currentBsonType == MongoDB.Bson.BsonType.Null)
+            {
+                context.Reader.ReadNull();
+                return null;
+            }
+
+            context.Reader.ReadStartDocument();
+
+            string object_type = context.Reader.ReadString();
+
+            long currentDeliveryId = context.Reader.ReadInt64();
+            UnconfirmedDelivery[] unconfirmedDeliveries = null;
+
+            var name = context.Reader.ReadName(MongoDB.Bson.IO.Utf8NameDecoder.Instance);
+            if (name == "UnconfirmedDeliveries")
+            {
+                unconfirmedDeliveries = BsonSerializer.Deserialize<UnconfirmedDelivery[]>(context.Reader);
+            }
+
+            context.Reader.ReadEndDocument();
+
+            var result = new AtLeastOnceDeliverySnapshot(currentDeliveryId, unconfirmedDeliveries);
+            return result;
+        }
+
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, AtLeastOnceDeliverySnapshot value)
+        {
+            context.Writer.WriteStartDocument();
+
+            context.Writer.WriteName("_t");
+            context.Writer.WriteString(value.GetType().Name);
+
+            context.Writer.WriteName("CurrentDeliveryId");
+            context.Writer.WriteInt64(value.CurrentDeliveryId);
+
+            context.Writer.WriteName("UnconfirmedDeliveries");
+            BsonSerializer.Serialize<UnconfirmedDelivery[]>(context.Writer, value.UnconfirmedDeliveries);
+
+            context.Writer.WriteEndDocument();
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Snapshot/Serializers/UnconfirmedDeliverySerializer.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/Serializers/UnconfirmedDeliverySerializer.cs
@@ -1,0 +1,57 @@
+using Akka.Actor;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Akka.Persistence.MongoDb.Snapshot.Serializers
+{
+    public class UnconfirmedDeliverySerializer : SerializerBase<UnconfirmedDelivery>
+    {
+        public override UnconfirmedDelivery Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            var currentBsonType = context.Reader.GetCurrentBsonType();
+
+            if (currentBsonType == MongoDB.Bson.BsonType.Null)
+            {
+                context.Reader.ReadNull();
+                return null;
+            }
+
+            context.Reader.ReadStartDocument();
+
+            string object_type = context.Reader.ReadString();
+
+            long deliveryId = context.Reader.ReadInt64();
+            ActorPath destination = ActorPath.Parse(context.Reader.ReadString());
+            object message = null;
+
+            var name = context.Reader.ReadName(MongoDB.Bson.IO.Utf8NameDecoder.Instance);
+            if (name == "Message")
+            {
+                message = BsonSerializer.Deserialize(context.Reader, typeof(object));
+            }
+
+            context.Reader.ReadEndDocument();
+
+            UnconfirmedDelivery result = new UnconfirmedDelivery(deliveryId, destination, message);
+            return result;
+        }
+
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, UnconfirmedDelivery value)
+        {
+            context.Writer.WriteStartDocument();
+            context.Writer.WriteName("_t");
+            context.Writer.WriteString(value.GetType().Name);
+
+            context.Writer.WriteName("DeliveryId");
+            context.Writer.WriteInt64(value.DeliveryId);
+
+            context.Writer.WriteName("Destination");
+            context.Writer.WriteString(value.Destination.ToSerializationFormat());
+
+            context.Writer.WriteName("Message");
+            BsonSerializer.Serialize(context.Writer, value.Message);
+
+            context.Writer.WriteEndDocument();
+        }
+    }
+}


### PR DESCRIPTION
To store the AtLeastOnceDeliverySnapshot into mongodb there must be an serializer for the AtLeastOnceDeliverySnapshot and UnconfirmedDelivery types.

In addition I change the SaveAsync behavior, so the it is possible to update the snapshot because,
it make sense to update the snapshot to remove the UnconfirmedDelivery messages from the AtLeastOnceDeliverySnapshot, if they are confirmed without any events in the meantime.
