### PR TITLE
Update Index Creation to use CreateIndexModel<T> syntax

### DIFF
--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -129,9 +129,13 @@ namespace Akka.Persistence.MongoDb.Journal
 
                 if (_settings.AutoInitialize)
                 {
-                    collection.Indexes.CreateOneAsync(
-                        Builders<MetadataEntry>.IndexKeys
-                            .Ascending(entry => entry.PersistenceId))
+                    var modelWithAscendingPersistenceId = new CreateIndexModel<MetadataEntry>(
+                        Builders<MetadataEntry>
+                            .IndexKeys
+                            .Ascending(entry => entry.PersistenceId));
+
+                    collection.Indexes
+                        .CreateOneAsync(modelWithAscendingPersistenceId, cancellationToken:CancellationToken.None)
                             .Wait();
                 }
 

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Journal;
@@ -101,15 +102,22 @@ namespace Akka.Persistence.MongoDb.Journal
 
                 if (_settings.AutoInitialize)
                 {
-                    collection.Indexes.CreateOneAsync(
-                        Builders<JournalEntry>.IndexKeys
-                            .Ascending(entry => entry.PersistenceId)
-                            .Descending(entry => entry.SequenceNr))
-                            .Wait();
+                    var modelForEntryAndSequenceNr = new CreateIndexModel<JournalEntry>(Builders<JournalEntry>
+                        .IndexKeys
+                        .Ascending(entry => entry.PersistenceId)
+                        .Descending(entry => entry.SequenceNr));
 
-                    collection.Indexes.CreateOne(
-                        Builders<JournalEntry>.IndexKeys
-                        .Ascending(entry => entry.Ordering));
+                    collection.Indexes
+                        .CreateOneAsync(modelForEntryAndSequenceNr, cancellationToken:CancellationToken.None)
+                        .Wait();
+
+                    var modelWithOrdering = new CreateIndexModel<JournalEntry>(
+                        Builders<JournalEntry>
+                            .IndexKeys
+                            .Ascending(entry => entry.Ordering));
+
+                    collection.Indexes
+                        .CreateOne(modelWithOrdering);
                 }
 
                 return collection;

--- a/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Persistence.Snapshot;
 using Akka.Serialization;
@@ -78,10 +79,12 @@ namespace Akka.Persistence.MongoDb.Snapshot
                 var collection = snapshot.GetCollection<SnapshotEntry>(_settings.Collection);
                 if (_settings.AutoInitialize)
                 {
-                    collection.Indexes.CreateOneAsync(
-                        Builders<SnapshotEntry>.IndexKeys
+                    var modelWithAscendingPersistenceIdAndDescendingSequenceNr = new CreateIndexModel<SnapshotEntry>(Builders<SnapshotEntry>.IndexKeys
                         .Ascending(entry => entry.PersistenceId)
-                        .Descending(entry => entry.SequenceNr))
+                        .Descending(entry => entry.SequenceNr));
+
+                    collection.Indexes
+                        .CreateOneAsync(modelWithAscendingPersistenceIdAndDescendingSequenceNr, cancellationToken:CancellationToken.None)
                         .Wait();
                 }
 


### PR DESCRIPTION
Resolves #81.

The new index creation method utilizes an `IndexCreationModel<T>` as a parameter.

I was able to pass in the existing `Builder` objects to create the indexes.

I also added `cancellationToken:CancellationToken.None` on the async calls, but that may not be necessary.