### PR TITLE
added v1.3.14 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 1.3.13 September 24 2019 ####
-* Support for Akka.Persistence 1.3.13.
-* Fixed [serializer regression for Akka.Persistence.MongoDb v1.3.12](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/59)
+#### 1.3.14 October 04 2019 ####
+You can see [the full set of changes for Akka.Persistence.MongoDb v1.3.14 here](https://github.com/akkadotnet/Akka.Persistence.MongoDB/milestone/2).
+
+This PR fixes a number of problems stemming from implementations of Akka.Persistence.Query implementations that were incorrect.
 
 **Note: we're working on [adding support for future versions of Akka.Persistence.MongoDB and you should read them here if you plan on continuing to use the plugin](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).**

--- a/src/common.props
+++ b/src/common.props
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2019 Akka.NET Project</Copyright>
     <Authors>Akka.NET Contrib</Authors>
-    <VersionPrefix>1.3.13</VersionPrefix>
+    <VersionPrefix>1.3.14</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageReleaseNotes>Support for Akka.Persistence 1.3.13.
-Fixed [serializer regression for Akka.Persistence.MongoDb v1.3.12](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/59)
+    <PackageReleaseNotes>You can see [the full set of changes for Akka.Persistence.MongoDb v1.3.14 here](https://github.com/akkadotnet/Akka.Persistence.MongoDB/milestone/2).
+This PR fixes a number of problems stemming from implementations of Akka.Persistence.Query implementations that were incorrect.
 Note: we're working on [adding support for future versions of Akka.Persistence.MongoDB and you should read them here if you plan on continuing to use the plugin](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).**</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka Persistence journal and snapshot store backed by MongoDB database.</Description>


### PR DESCRIPTION
#### 1.3.14 October 04 2019 ####
You can see [the full set of changes for Akka.Persistence.MongoDb v1.3.14 here](https://github.com/akkadotnet/Akka.Persistence.MongoDB/milestone/2).

This PR fixes a number of problems stemming from implementations of Akka.Persistence.Query implementations that were incorrect.

**Note: we're working on [adding support for future versions of Akka.Persistence.MongoDB and you should read them here if you plan on continuing to use the plugin](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).**