### PR TITLE
v1.3.14 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 1.3.13 September 24 2019 ####
-* Support for Akka.Persistence 1.3.13.
-* Fixed [serializer regression for Akka.Persistence.MongoDb v1.3.12](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/59)
+#### 1.3.14 October 04 2019 ####
+You can see [the full set of changes for Akka.Persistence.MongoDb v1.3.14 here](https://github.com/akkadotnet/Akka.Persistence.MongoDB/milestone/2).
+
+This PR fixes a number of problems stemming from implementations of Akka.Persistence.Query implementations that were incorrect.
 
 **Note: we're working on [adding support for future versions of Akka.Persistence.MongoDB and you should read them here if you plan on continuing to use the plugin](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).**

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Mongo2Go" Version="2.2.8" />
+    <PackageReference Include="Mongo2Go" Version="2.2.12" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
@@ -1,0 +1,168 @@
+﻿using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Journal;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Akka.Streams;
+using Akka.Util.Internal;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class Bug61FixSpec : Akka.TestKit.Xunit2.TestKit, IClassFixture<DatabaseFixture>
+    {
+        public static readonly AtomicCounter Counter = new AtomicCounter(0);
+        private readonly ITestOutputHelper _output;
+
+        protected MongoDbReadJournal ReadJournal { get; }
+
+        protected IMaterializer Materializer { get; }
+
+        public class RealMsg
+        {
+            public RealMsg(string msg)
+            {
+                Msg = msg;
+            }
+            public string Msg { get; }
+        }
+
+        public const int MessageCount = 20;
+
+        public Bug61FixSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement()), "MongoDbCurrentEventsByTagSpec", output)
+        {
+            _output = output;
+            output.WriteLine(databaseFixture.ConnectionString + Counter.Current);
+            Materializer = Sys.Materializer();
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        /// <summary>
+        /// Reproduction spec for https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/61
+        /// </summary>
+        [Fact]
+        public async Task Bug61_Events_Recovered_By_Id_Should_Match_Tag()
+        {
+            var actor = Sys.ActorOf(TagActor.Props("x"));
+
+            actor.Tell(MessageCount);
+            ExpectMsg($"{MessageCount}-done", TimeSpan.FromSeconds(20));
+
+            var eventsById = await ReadJournal.CurrentEventsByPersistenceId("x", 0L, long.MaxValue)
+                .RunAggregate(ImmutableHashSet<EventEnvelope>.Empty, (agg, e) => agg.Add(e), Materializer);
+
+            eventsById.Count.Should().Be(MessageCount);
+
+            var eventsByTag = await ReadJournal.CurrentEventsByTag(typeof(RealMsg).Name)
+                .RunAggregate(ImmutableHashSet<EventEnvelope>.Empty, (agg, e) => agg.Add(e), Materializer);
+
+            eventsByTag.Count.Should().Be(MessageCount);
+
+            eventsById.All(x => x.Event is RealMsg).Should().BeTrue("Expected all events by id to be RealMsg");
+            eventsByTag.All(x => x.Event is RealMsg).Should().BeTrue("Expected all events by tag to be RealMsg");
+        }
+
+        private class TagActor : ReceivePersistentActor
+        {
+            public static Props Props(string id)
+            {
+                return Akka.Actor.Props.Create(() => new TagActor(id));
+            }
+
+            public TagActor(string id)
+            {
+                PersistenceId = id;
+
+                Command<int>(i =>
+                {
+                    var msgs = new List<RealMsg>();
+                    foreach (var n in Enumerable.Range(0, i))
+                    {
+                        msgs.Add(new RealMsg(i.ToString()));
+                    }
+                    PersistAll(msgs, m =>
+                    {
+                        if (LastSequenceNr >= i)
+                        {
+                            Sender.Tell($"{i}-done");
+                        }
+                    });
+                });
+
+                Command<RealMsg>(r =>
+                {
+                    Persist(r, e =>
+                    {
+                        Sender.Tell($"{e.Msg}-done");
+                    });
+                });
+            }
+
+            public override string PersistenceId { get; }
+        }
+
+        private class EventTagger : IWriteEventAdapter
+        {
+            public string DefaultTag { get; }
+
+            public EventTagger()
+            {
+                DefaultTag = "accounts";
+            }
+
+            public string Manifest(object evt)
+            {
+                return string.Empty;
+            }
+
+            public object ToJournal(object evt)
+            {
+                return new Tagged(evt, ImmutableHashSet<string>.Empty.Add(DefaultTag).Add(evt.GetType().Name));
+            }
+        }
+
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + id + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                            event-adapters {
+                                tagger  = """ + typeof(EventTagger).AssemblyQualifiedName + @"""
+                            }
+                            event-adapter-bindings = {
+                                """ + typeof(RealMsg).AssemblyQualifiedName + @""" = tagger
+                            }
+                            stored-as = binary
+                        }
+                    }
+                    query {
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb""
+                            refresh-interval = 1s
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
@@ -72,6 +72,47 @@ namespace Akka.Persistence.MongoDb.Tests
             eventsByTag.All(x => x.Event is RealMsg).Should().BeTrue("Expected all events by tag to be RealMsg");
         }
 
+        /// <summary>
+        /// Reproduction spec for https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/80
+        /// </summary>
+        [Fact]
+        public void Bug80_CurrentEventsByTag_should_Recover_until_end()
+        {
+            var actor = Sys.ActorOf(TagActor.Props("y"));
+            var msgCount = 1200;
+            actor.Tell(msgCount);
+            ExpectMsg($"{msgCount}-done", TimeSpan.FromSeconds(20));
+
+            var eventsByTag = ReadJournal.CurrentEventsByTag(typeof(RealMsg).Name)
+                .RunForeach(e => TestActor.Tell(e), Materializer);
+
+            ReceiveN(msgCount);
+        }
+
+        /// <summary>
+        /// Making sure EventsByTag didn't break during implementation of https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/80
+        /// </summary>
+        [Fact]
+        public void Bug80_AllEventsByTag_should_Recover_all_messages()
+        {
+            var actor = Sys.ActorOf(TagActor.Props("y"));
+            var msgCount = 1200;
+            actor.Tell(msgCount);
+            ExpectMsg($"{msgCount}-done", TimeSpan.FromSeconds(20));
+
+            var eventsByTag = ReadJournal.EventsByTag(typeof(RealMsg).Name)
+                .RunForeach(e => TestActor.Tell(e), Materializer);
+
+            // can't do this because Offset isn't IComparable
+            // ReceiveN(msgCount).Cast<EventEnvelope>().Select(x => x.Offset).Should().BeInAscendingOrder();
+            ReceiveN(msgCount);
+
+            // should receive more messages after the fact
+            actor.Tell(msgCount);
+            ExpectMsg($"{msgCount}-done", TimeSpan.FromSeconds(20));
+            ReceiveN(msgCount);
+        }
+        
         private class TagActor : ReceivePersistentActor
         {
             public static Props Props(string id)

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -193,9 +193,10 @@ namespace Akka.Persistence.MongoDb.Journal
                 .Sort(sort)
                 .Limit(limitValue)
                 .ForEachAsync(entry => {
-                    var persistent = new Persistent(entry.Payload, entry.SequenceNr, entry.PersistenceId, entry.Manifest, entry.IsDeleted, ActorRefs.NoSender, null);
+                    var persistent = ToPersistenceRepresentation(entry, ActorRefs.NoSender);
                     foreach (var adapted in AdaptFromJournal(persistent))
-                        replay.ReplyTo.Tell(new ReplayedTaggedMessage(adapted, tag, entry.Ordering.Value), ActorRefs.NoSender);
+                        replay.ReplyTo.Tell(new ReplayedTaggedMessage(adapted, tag, entry.Ordering.Value), 
+                            ActorRefs.NoSender);
                     maxOrderingId = entry.Ordering.Value;
                 });
 

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -247,16 +247,29 @@ namespace Akka.Persistence.MongoDb.Journal
 
         protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
         {
-            var allTags = new HashSet<string>();
+            var allTags = ImmutableHashSet<string>.Empty;
+            var persistentIds = new HashSet<string>();
             var messageList = messages.ToList();
 
             var writeTasks = messageList.Select(async message => {
-                var persistentMessages = ((IImmutableList<IPersistentRepresentation>)message.Payload).ToArray();
+                var persistentMessages = ((IImmutableList<IPersistentRepresentation>)message.Payload);
 
-                var journalEntries = persistentMessages.Select(ToJournalEntry).ToList();
+                if (HasTagSubscribers)
+                {
+                    foreach (var p in persistentMessages)
+                    {
+                        if (p.Payload is Tagged t)
+                        {
+                            allTags = allTags.Union(t.Tags);
+                        }
+                    }
+                }
+
+                var journalEntries = persistentMessages.Select(ToJournalEntry);
                 await _journalCollection.Value.InsertManyAsync(journalEntries);
 
-                NotifyNewPersistenceIdAdded(message.PersistenceId);
+                if (HasPersistenceIdSubscribers)
+                    persistentIds.Add(message.PersistenceId);
             });
 
             await SetHighSequenceId(messageList);
@@ -265,6 +278,14 @@ namespace Akka.Persistence.MongoDb.Journal
                 .Factory
                 .ContinueWhenAll(writeTasks.ToArray(),
                     tasks => tasks.Select(t => t.IsFaulted ? TryUnwrapException(t.Exception) : null).ToImmutableList());
+
+            if (HasPersistenceIdSubscribers)
+            {
+                foreach (var id in persistentIds)
+                {
+                    NotifyPersistenceIdChange(id);
+                }
+            }
 
             if (HasTagSubscribers && allTags.Count != 0) {
                 foreach (var tag in allTags) {

--- a/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Persistence.Snapshot;
 using Akka.Serialization;
@@ -78,10 +79,12 @@ namespace Akka.Persistence.MongoDb.Snapshot
                 var collection = snapshot.GetCollection<SnapshotEntry>(_settings.Collection);
                 if (_settings.AutoInitialize)
                 {
-                    collection.Indexes.CreateOneAsync(
-                        Builders<SnapshotEntry>.IndexKeys
+                    var modelWithAscendingPersistenceIdAndDescendingSequenceNr = new CreateIndexModel<SnapshotEntry>(Builders<SnapshotEntry>.IndexKeys
                         .Ascending(entry => entry.PersistenceId)
-                        .Descending(entry => entry.SequenceNr))
+                        .Descending(entry => entry.SequenceNr));
+
+                    collection.Indexes
+                        .CreateOneAsync(modelWithAscendingPersistenceIdAndDescendingSequenceNr, cancellationToken:CancellationToken.None)
                         .Wait();
                 }
 

--- a/src/common.props
+++ b/src/common.props
@@ -14,7 +14,7 @@ Note: we're working on [adding support for future versions of Akka.Persistence.M
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.3.1</XunitVersion>
+    <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
     <AkkaVersion>1.3.13</AkkaVersion>
   </PropertyGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2019 Akka.NET Project</Copyright>
     <Authors>Akka.NET Contrib</Authors>
-    <VersionPrefix>1.3.13</VersionPrefix>
+    <VersionPrefix>1.3.14</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageReleaseNotes>Support for Akka.Persistence 1.3.13.
-Fixed [serializer regression for Akka.Persistence.MongoDb v1.3.12](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/59)
+    <PackageReleaseNotes>You can see [the full set of changes for Akka.Persistence.MongoDb v1.3.14 here](https://github.com/akkadotnet/Akka.Persistence.MongoDB/milestone/2).
+This PR fixes a number of problems stemming from implementations of Akka.Persistence.Query implementations that were incorrect.
 Note: we're working on [adding support for future versions of Akka.Persistence.MongoDB and you should read them here if you plan on continuing to use the plugin](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).**</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka Persistence journal and snapshot store backed by MongoDB database.</Description>


### PR DESCRIPTION
#### 1.3.14 October 04 2019 ####
You can see [the full set of changes for Akka.Persistence.MongoDb v1.3.14 here](https://github.com/akkadotnet/Akka.Persistence.MongoDB/milestone/2).

This PR fixes a number of problems stemming from implementations of Akka.Persistence.Query implementations that were incorrect.

**Note: we're working on [adding support for future versions of Akka.Persistence.MongoDB and you should read them here if you plan on continuing to use the plugin](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).**