### PR TITLE
added v1.4.0-beta2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,2 @@
-#### 1.4.0-beta1 October 30 2019 ####
-Beta release of Akka.Persistence.MongoDB which implements the [new standardized Akka.Persistence serialization paradigm](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72) going forward. Has full backwards compatibility for reading events which were written in 1.3.[0-14] style serialization.
+#### 1.4.0-beta2 October 31 2019 ####
+Fixed [an issue with Snapshot serialization in v1.4.0-beta1](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/98)

--- a/src/common.props
+++ b/src/common.props
@@ -6,7 +6,7 @@
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageReleaseNotes>Beta release of Akka.Persistence.MongoDB which implements the [new standardized Akka.Persistence serialization paradigm](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72) going forward. Has full backwards compatibility for reading events which were written in 1.3.[0-14] style serialization.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed [an issue with Snapshot serialization in v1.4.0-beta1](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/98)</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka Persistence journal and snapshot store backed by MongoDB database.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
#### 1.4.0-beta2 October 31 2019 ####
Fixed [an issue with Snapshot serialization in v1.4.0-beta1](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/98)