### PR TITLE
v1.4.0-beta3 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,7 @@ akka.persistence {
 ```
 
 ### Serialization
-The events and snapshots are stored as BsonDocument. On the previous version of this driver you needed to register your types with BsonClassMap before you could use your persistence actor, otherwise the recovery would fail and you'd receive a RecoveryFailure with the message:  
->An error occurred while deserializing the Payload property of class \<Journal or Snapshot class>: Unknown discriminator value '\<your type>'
-
-#### **Since now, all types are registered automatically for you so you don't need to use BsonClassMap to serialize/deserialize your types!**
+Going from v1.4.0 onwards, all events and snapshots are saved as byte arrays using the standard Akka.Persistence format.
 
 ### Notice
 - The MongoDB operator to limit the number of documents in a query only accepts an integer while akka provides a long as maximum for the loading of events during the replay. Internally the long value is cast to an integer and if the value is higher then Int32.MaxValue, Int32.MaxValue is used. So if you have stored more then 2,147,483,647 events for a single PersistenceId, you may have a problem :wink:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ akka.persistence {
 
 			# metadata collection
 			metadata-collection = "Metadata"
+
+			# For users with legacy data, who want to keep writing data to MongoDb using the original BSON format
+			# and not the standard binary format introduced in v1.4.0 (see https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72)
+			# enable this setting via `legacy-serialization = on`.
+			#
+			# NOTE: this will likely break features such as Akka.Cluster.Sharding, IActorRef serialization, AtLeastOnceDelivery, and more.
+			legacy-serialization = off
 		}
 	}
 
@@ -66,13 +73,44 @@ akka.persistence {
 
 			# MongoDb collection corresponding with persistent snapshot store
 			collection = "SnapshotStore"
+
+			# For users with legacy data, who want to keep writing data to MongoDb using the original BSON format
+			# and not the standard binary format introduced in v1.4.0 (see https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72)
+			# enable this setting via `legacy-serialization = on`.
+			#
+			# NOTE: this will likely break features such as Akka.Cluster.Sharding, IActorRef serialization, AtLeastOnceDelivery, and more.
+			legacy-serialization = off
 		}
 	}
 }
 ```
 
 ### Serialization
-Going from v1.4.0 onwards, all events and snapshots are saved as byte arrays using the standard Akka.Persistence format.
+[Going from v1.4.0 onwards, all events and snapshots are saved as byte arrays using the standard Akka.Persistence format](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).
+
+However, in the event that you have one of the following use cases:
+
+1. Legacy data all stored in the original BSON / "object" format;
+2. A use case where BSON is preferable, i.e. so it can be queried directly via MongoDb queries rather than Akka.Persistence.Query; or
+3. A requirement to keep all data in human-readable form.
+
+Then you can disable binary serialization (enabled by default) via the following HOCON:
+
+```
+akka.persistence.mongodb{
+   journal{
+    legacy-serialization = off
+  }
+
+  snapshot-store{
+   legacy-serialization = off
+ }
+}
+```
+
+Setting `legacy-serialization = on` will allow you to save objects in a BSON format.
+
+**WARNING**: However, `legacy-serialization = on` will break Akka.NET serialization. `IActorRef`s, Akka.Cluster.Sharding, `AtLeastOnceDelivery` actors, and other built-in Akka.NET use cases can't be properly supported using this format. Use it at your own risk.
 
 ### Notice
 - The MongoDB operator to limit the number of documents in a query only accepts an integer while akka provides a long as maximum for the loading of events during the replay. Internally the long value is cast to an integer and if the value is higher then Int32.MaxValue, Int32.MaxValue is used. So if you have stored more then 2,147,483,647 events for a single PersistenceId, you may have a problem :wink:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,29 @@
-#### 1.4.0-beta2 October 31 2019 ####
-Fixed [an issue with Snapshot serialization in v1.4.0-beta1](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/98)
+#### 1.4.0-beta3 February 04 2020 ####
+
+Introduced legacy serialization modes.
+
+[Going from v1.4.0 onwards, all events and snapshots are saved as byte arrays using the standard Akka.Persistence format](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).
+
+However, in the event that you have one of the following use cases:
+
+1. Legacy data all stored in the original BSON / "object" format;
+2. A use case where BSON is preferable, i.e. so it can be queried directly via MongoDb queries rather than Akka.Persistence.Query; or
+3. A requirement to keep all data in human-readable form.
+
+Then you can disable binary serialization (enabled by default) via the following HOCON:
+
+```
+akka.persistence.mongodb{
+   journal{
+    legacy-serialization = off
+  }
+
+  snapshot-store{
+   legacy-serialization = off
+ }
+}
+```
+
+Setting `legacy-serialization = on` will allow you to save objects in a BSON format.
+
+**WARNING**: However, `legacy-serialization = on` will break Akka.NET serialization. `IActorRef`s, Akka.Cluster.Sharding, `AtLeastOnceDelivery` actors, and other built-in Akka.NET use cases can't be properly supported using this format. Use it at your own risk.

--- a/build.fsx
+++ b/build.fsx
@@ -23,15 +23,20 @@ let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynami
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
 let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
+let releaseNotes =
+    File.ReadLines (__SOURCE_DIRECTORY__ @@ "RELEASE_NOTES.md")
+    |> ReleaseNotesHelper.parseReleaseNotes
+
+let versionFromReleaseNotes =
+    match releaseNotes.SemVer.PreRelease with
+    | Some r -> r.Origin
+    | None -> ""
+
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix
-    | "" -> ""
+    | "" -> versionFromReleaseNotes
     | str -> str
-    
-let releaseNotes =
-    File.ReadLines "./RELEASE_NOTES.md"
-    |> ReleaseNotesHelper.parseReleaseNotes
 
 // Directories
 let toolsDir = __SOURCE_DIRECTORY__ @@ "tools"
@@ -139,7 +144,7 @@ Target "SignPackages" (fun _ ->
     if(canSign) then
         log "Signing information is available."
         
-        let assemblies = !! (outputNuGet @@ "*.nupkg")
+        let assemblies = !! (outputNuGet @@ "*.*upkg")
 
         let signPath =
             let globalTool = tryFindFileOnPath "SignClient.exe"

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Mongo2Go" Version="2.2.12" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationJournalSpec.cs
@@ -1,0 +1,47 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbJournalSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2019 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2019 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Journal;
+using Xunit;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbLegacySerializationJournalSpec : JournalSpec, IClassFixture<DatabaseFixture>
+    {
+        protected override bool SupportsRejectingNonSerializableObjects { get; } = false;
+
+        protected override bool SupportsSerialization => false;
+
+        public MongoDbLegacySerializationJournalSpec(DatabaseFixture databaseFixture) : base(CreateSpecConfig(databaseFixture), "MongoDbJournalSpec")
+        {
+            Initialize();
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
+        {
+            var specString = @"
+                akka.test.single-expect-default = 3s
+                akka.persistence {
+                    publish-plugin-commands = on
+                    journal {
+                        plugin = ""akka.persistence.journal.mongodb""
+                        mongodb {
+                            class = ""Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb""
+                            connection-string = """ + databaseFixture.ConnectionString + @"""
+                            auto-initialize = on
+                            collection = ""EventJournal""
+                            legacy-serialization = on
+                        }
+                    }
+                }";
+
+            return ConfigurationFactory.ParseString(specString);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationSnapshotStoreSpec.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MongoDbSnapshotStoreSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Snapshot;
+using Xunit;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    // TODO: enable this spec once https://github.com/akkadotnet/akka.net/pull/4190 is available via Akka.NET v1.4.0-beta5 or higher
+    //[Collection("MongoDbSpec")]
+    //public class MongoDbLegacySerializationSnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<DatabaseFixture>
+    //{
+    //    protected override bool SupportsSerialization => false;
+
+    //    public MongoDbLegacySerializationSnapshotStoreSpec(DatabaseFixture databaseFixture) : base(CreateSpecConfig(databaseFixture), "MongoDbSnapshotStoreSpec")
+    //    {
+    //        Initialize();
+    //    }
+
+    //    private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
+    //    {
+    //        var specString = @"
+    //            akka.test.single-expect-default = 3s
+    //            akka.persistence {
+    //                publish-plugin-commands = on
+    //                snapshot-store {
+    //                    plugin = ""akka.persistence.snapshot-store.mongodb""
+    //                    mongodb {
+    //                        class = ""Akka.Persistence.MongoDb.Snapshot.MongoDbSnapshotStore, Akka.Persistence.MongoDb""
+    //                        connection-string = """ + databaseFixture.ConnectionString + @"""
+    //                        auto-initialize = on
+    //                        collection = ""SnapshotStore""
+    //                        legacy-serialization = on
+    //                    }
+    //                }
+    //            }";
+
+    //        return ConfigurationFactory.ParseString(specString);
+    //    }
+    //}
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
@@ -22,6 +22,7 @@ namespace Akka.Persistence.MongoDb.Tests
             mongoPersistence.JournalSettings.AutoInitialize.Should().BeFalse();
             mongoPersistence.JournalSettings.Collection.Should().Be("EventJournal");
             mongoPersistence.JournalSettings.MetadataCollection.Should().Be("Metadata");
+            mongoPersistence.JournalSettings.LegacySerialization.Should().BeFalse();
         }
 
         [Fact]
@@ -32,6 +33,7 @@ namespace Akka.Persistence.MongoDb.Tests
             mongoPersistence.SnapshotStoreSettings.ConnectionString.Should().Be(string.Empty);
             mongoPersistence.SnapshotStoreSettings.AutoInitialize.Should().BeFalse();
             mongoPersistence.SnapshotStoreSettings.Collection.Should().Be("SnapshotStore");
+            mongoPersistence.SnapshotStoreSettings.LegacySerialization.Should().BeFalse();
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
@@ -39,34 +39,4 @@ namespace Akka.Persistence.MongoDb.Tests
             return ConfigurationFactory.ParseString(specString);
         }
     }
-
-    [Collection("MongoDbSpec")]
-    public class MongoDbBinarySnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<DatabaseFixture>
-    {
-        public MongoDbBinarySnapshotStoreSpec(DatabaseFixture databaseFixture) : base(CreateSpecConfig(databaseFixture), "MongoDbSnapshotStoreSpec")
-        {
-            Initialize();
-        }
-
-        private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
-        {
-            var specString = @"
-                akka.test.single-expect-default = 3s
-                akka.persistence {
-                    publish-plugin-commands = on
-                    snapshot-store {
-                        plugin = ""akka.persistence.snapshot-store.mongodb""
-                        mongodb {
-                            class = ""Akka.Persistence.MongoDb.Snapshot.MongoDbSnapshotStore, Akka.Persistence.MongoDb""
-                            connection-string = """ + databaseFixture.ConnectionString + @"""
-                            auto-initialize = on
-                            collection = ""SnapshotStore""
-                            stored-as = binary
-                        }
-                    }
-                }";
-
-            return ConfigurationFactory.ParseString(specString);
-        }
-    }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/Serialization/MongoDbJournalSerializationSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Serialization/MongoDbJournalSerializationSpec.cs
@@ -33,7 +33,6 @@ namespace Akka.Persistence.MongoDb.Tests.Serialization
                             connection-string = """ + databaseFixture.ConnectionString + @"""
                             auto-initialize = on
                             collection = ""EventJournal""
-                            stored-as = object
                         }
                     }
                 }";

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
-    <PackageReference Include="MongoDB.Driver" Version="2.10.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.10.1" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
-    <PackageReference Include="MongoDB.Driver" Version="2.9.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.10.0" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.MongoDb.Journal
         private readonly Dictionary<string, ISet<IActorRef>> _persistenceIdSubscribers
             = new Dictionary<string, ISet<IActorRef>>();
 
-        private Akka.Serialization.Serialization _serialization;
+        private readonly Akka.Serialization.Serialization _serialization;
 
         public MongoDbJournal()
         {
@@ -291,7 +291,26 @@ namespace Akka.Persistence.MongoDb.Journal
                 message = message.WithPayload(payload); // need to update the internal payload when working with tags
             }
 
+            // per https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/107
+            // BSON serialization
+            if (_settings.LegacySerialization)
+            {
+                var manifest = string.IsNullOrEmpty(message.Manifest) ? payload.GetType().TypeQualifiedName() : message.Manifest;
+                return new JournalEntry
+                {
+                    Id = message.PersistenceId + "_" + message.SequenceNr,
+                    Ordering = new BsonTimestamp(0), // Auto-populates with timestamp
+                    IsDeleted = message.IsDeleted,
+                    Payload = payload,
+                    PersistenceId = message.PersistenceId,
+                    SequenceNr = message.SequenceNr,
+                    Manifest = manifest,
+                    Tags = tagged.Tags?.ToList(),
+                    SerializerId = null // don't need a serializer ID here either; only for backwards-compat
+                };
+            }
 
+            // default serialization
             var serializer = _serialization.FindSerializerFor(message);
             var binary = serializer.ToBinary(message);
 
@@ -306,7 +325,7 @@ namespace Akka.Persistence.MongoDb.Journal
                 SequenceNr = message.SequenceNr,
                 Manifest = string.Empty, // don't need a manifest here - it's embedded inside the PersistentMessage
                 Tags = tagged.Tags?.ToList(),
-                SerializerId = null // don't need a serializer ID here either; only for backwards-comat
+                SerializerId = null // don't need a serializer ID here either; only for backwards-compat
             };
         }
 

--- a/src/Akka.Persistence.MongoDb/MongoDbSettings.cs
+++ b/src/Akka.Persistence.MongoDb/MongoDbSettings.cs
@@ -30,11 +30,17 @@ namespace Akka.Persistence.MongoDb
         /// </summary>
         public string Collection { get; private set; }
 
+        /// <summary>
+        /// When true, enables BSON serialization (which breaks features like Akka.Cluster.Sharding, AtLeastOnceDelivery, and so on.)
+        /// </summary>
+        public bool LegacySerialization { get; }
+
         protected MongoDbSettings(Config config)
         {
             ConnectionString = config.GetString("connection-string");
             Collection = config.GetString("collection");
             AutoInitialize = config.GetBoolean("auto-initialize");
+            LegacySerialization = config.GetBoolean("legacy-serialization");
         }
     }
 

--- a/src/Akka.Persistence.MongoDb/reference.conf
+++ b/src/Akka.Persistence.MongoDb/reference.conf
@@ -18,6 +18,13 @@
 
 			# metadata collection
 			metadata-collection = "Metadata"
+
+			# For users with legacy data, who want to keep writing data to MongoDb using the original BSON format
+			# and not the standard binary format introduced in v1.4.0 (see https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72)
+			# enable this setting via `legacy-serialization = on`.
+			#
+			# NOTE: this will likely break features such as Akka.Cluster.Sharding, IActorRef serialization, AtLeastOnceDelivery, and more.
+			legacy-serialization = off
 		}
 	}
 
@@ -37,6 +44,13 @@
 
 			# MongoDb collection corresponding with persistent snapshot store
 			collection = "SnapshotStore"
+
+			# For users with legacy data, who want to keep writing data to MongoDb using the original BSON format
+			# and not the standard binary format introduced in v1.4.0 (see https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72)
+			# enable this setting via `legacy-serialization = on`.
+			#
+			# NOTE: this will likely break features such as Akka.Cluster.Sharding, IActorRef serialization, AtLeastOnceDelivery, and more.
+			legacy-serialization = off
 		}
 	}
 

--- a/src/common.props
+++ b/src/common.props
@@ -14,6 +14,6 @@
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.4.0</TestSdkVersion>
-    <AkkaVersion>1.4.0-beta*</AkkaVersion>
+    <AkkaVersion>1.4.0-beta4</AkkaVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.3.0</TestSdkVersion>
+    <TestSdkVersion>16.4.0</TestSdkVersion>
     <AkkaVersion>1.4.0-beta*</AkkaVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -1,12 +1,30 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2013-2019 Akka.NET Project</Copyright>
+    <Copyright>Copyright © 2013-2020 Akka.NET Project</Copyright>
     <Authors>Akka.NET Contrib</Authors>
     <VersionPrefix>1.4.0</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageReleaseNotes>Fixed [an issue with Snapshot serialization in v1.4.0-beta1](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/98)</PackageReleaseNotes>
+    <PackageReleaseNotes>Introduced legacy serialization modes.
+[Going from v1.4.0 onwards, all events and snapshots are saved as byte arrays using the standard Akka.Persistence format](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).
+However, in the event that you have one of the following use cases:
+1. Legacy data all stored in the original BSON / "object" format;
+2. A use case where BSON is preferable, i.e. so it can be queried directly via MongoDb queries rather than Akka.Persistence.Query; or
+3. A requirement to keep all data in human-readable form.
+Then you can disable binary serialization (enabled by default) via the following HOCON:
+```
+akka.persistence.mongodb{
+journal{
+legacy-serialization = off
+}
+snapshot-store{
+legacy-serialization = off
+}
+}
+```
+Setting `legacy-serialization = on` will allow you to save objects in a BSON format.
+WARNING**: However, `legacy-serialization = on` will break Akka.NET serialization. `IActorRef`s, Akka.Cluster.Sharding, `AtLeastOnceDelivery` actors, and other built-in Akka.NET use cases can't be properly supported using this format. Use it at your own risk.</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka Persistence journal and snapshot store backed by MongoDB database.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
@@ -15,5 +33,17 @@
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.4.0</TestSdkVersion>
     <AkkaVersion>1.4.0-beta4</AkkaVersion>
+  </PropertyGroup>
+  <!-- SourceLink support for all Akka.NET projects -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
#### 1.4.0-beta3 February 04 2020 ####

Introduced legacy serialization modes.

[Going from v1.4.0 onwards, all events and snapshots are saved as byte arrays using the standard Akka.Persistence format](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/72).

However, in the event that you have one of the following use cases:

1. Legacy data all stored in the original BSON / "object" format;
2. A use case where BSON is preferable, i.e. so it can be queried directly via MongoDb queries rather than Akka.Persistence.Query; or
3. A requirement to keep all data in human-readable form.

Then you can disable binary serialization (enabled by default) via the following HOCON:

```
akka.persistence.mongodb{
   journal{
    legacy-serialization = off
  }

  snapshot-store{
   legacy-serialization = off
 }
}
```

Setting `legacy-serialization = on` will allow you to save objects in a BSON format.

**WARNING**: However, `legacy-serialization = on` will break Akka.NET serialization. `IActorRef`s, Akka.Cluster.Sharding, `AtLeastOnceDelivery` actors, and other built-in Akka.NET use cases can't be properly supported using this format. Use it at your own risk.