### PR TITLE
Added v1.4.12 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 1.4.5 May 12 2020 ####
+#### 1.4.12 November 26 2020 ####
 
-* Bump Akka version to 1.4.5
-* [Fixed: InvalidCastExceptions when recovering legacy data in ToPersistenceRepresentation and ToSelectedSnapshot](https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/134)
-* Upgraded MongoDb driver to 2.10.4
+* Bump Akka version to 1.4.12
+* Corrected `CurrentPersistentIds` query and `AllPersistentIds` queries to be more memory efficient and query entity ID data directly from Mongo
+* Introduced `AllEvents` and `CurrentEvents` query to read the entire MongoDb journal
+* Deprecated previous `GetMaxSeqNo` behavior - we no longer query the max sequence number directly from the journal AND the metadata collection. We only get that data directly from the metadata collection itself, which should make this query an O(1) operation rather than O(n)


### PR DESCRIPTION
#### 1.4.12 November 26 2020 ####

* Bump Akka version to 1.4.12
* Corrected `CurrentPersistentIds` query and `AllPersistentIds` queries to be more memory efficient and query entity ID data directly from Mongo
* Introduced `AllEvents` and `CurrentEvents` query to read the entire MongoDb journal
* Deprecated previous `GetMaxSeqNo` behavior - we no longer query the max sequence number directly from the journal AND the metadata collection. We only get that data directly from the metadata collection itself, which should make this query an O(1) operation rather than O(n)