### PR TITLE
fixed MongoDbJournal atomicity guarantees

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/Bug25FixSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Bug25FixSpec.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace Akka.Persistence.MongoDb.Tests
 {
-    public class Bug25FixSpec : Akka.TestKit.Xunit2.TestKit, IClassFixture<DatabaseFixture>
+    public class Bug25FixSpec : Akka.TestKit.Xunit2.TestKit
     {
         class MyJournalActor : ReceivePersistentActor
         {

--- a/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class Bug61FixSpec : Akka.TestKit.Xunit2.TestKit, IClassFixture<DatabaseFixture>
+    public class Bug61FixSpec : Akka.TestKit.Xunit2.TestKit
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/DatabaseFixture.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/DatabaseFixture.cs
@@ -7,10 +7,18 @@
 
 using Mongo2Go;
 using System;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using Xunit;
 
 namespace Akka.Persistence.MongoDb.Tests
 {
-    public class DatabaseFixture : IDisposable
+    [CollectionDefinition("MongoDbSpec")]
+    public sealed class MongoDbFixture : ICollectionFixture<DatabaseFixture>
+    {
+    }
+
+    public class DatabaseFixture : IAsyncLifetime
     {
         private MongoDbRunner _runner;
 
@@ -18,13 +26,26 @@ namespace Akka.Persistence.MongoDb.Tests
 
         public DatabaseFixture()
         {
-            _runner = MongoDbRunner.Start();
-            ConnectionString = _runner.ConnectionString + "akkanet";
+            
         }
 
         public void Dispose()
         {
+           
+        }
+
+        public Task InitializeAsync()
+        {
+            _runner = MongoDbRunner.Start(singleNodeReplSet: true);
+            var strParts = _runner.ConnectionString.Split("?");
+            ConnectionString = $"{strParts[0]}akkadotnet/?{strParts[1]}";
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
             _runner.Dispose();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbAllEventsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbAllEventsSpec.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbAllEventsSpec: AllEventsSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbAllEventsSpec: AllEventsSpec
     {
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
         {

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentAllEventsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentAllEventsSpec.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbCurrentAllEventsSpec : CurrentAllEventsSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbCurrentAllEventsSpec : CurrentAllEventsSpec
     {
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
         {

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByPersistenceIdsSpec.cs
@@ -16,7 +16,7 @@ using Akka.Util.Internal;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbCurrentEventsByPersistenceIdsSpec : TCK.Query.CurrentEventsByPersistenceIdSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbCurrentEventsByPersistenceIdsSpec : TCK.Query.CurrentEventsByPersistenceIdSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByTagSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentEventsByTagSpec.cs
@@ -21,7 +21,7 @@ using System.Diagnostics;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbCurrentEventsByTagSpec : Akka.Persistence.TCK.Query.CurrentEventsByTagSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbCurrentEventsByTagSpec : Akka.Persistence.TCK.Query.CurrentEventsByTagSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentPersistenceIdsSpec.cs
@@ -21,7 +21,7 @@ using System.Diagnostics;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbCurrentPersistenceIdsSpec : Akka.Persistence.TCK.Query.CurrentPersistenceIdsSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbCurrentPersistenceIdsSpec : Akka.Persistence.TCK.Query.CurrentPersistenceIdsSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByPersistenceIdSpec.cs
@@ -16,7 +16,7 @@ using Akka.Util.Internal;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbEventsByPersistenceIdSpec : Akka.Persistence.TCK.Query.EventsByPersistenceIdSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbEventsByPersistenceIdSpec : Akka.Persistence.TCK.Query.EventsByPersistenceIdSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByTagSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByTagSpec.cs
@@ -18,7 +18,7 @@ using Akka.Actor;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbEventsByTagSpec : Akka.Persistence.TCK.Query.EventsByTagSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbEventsByTagSpec : Akka.Persistence.TCK.Query.EventsByTagSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalPerfSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalPerfSpec.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbJournalPerfSpec: JournalPerfSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbJournalPerfSpec: JournalPerfSpec
     {
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id)
         {

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSpec.cs
@@ -12,7 +12,7 @@ using Akka.Configuration;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbJournalSpec : JournalSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbJournalSpec : JournalSpec
     {
         protected override bool SupportsRejectingNonSerializableObjects { get; } = false;        
 

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationJournalSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationJournalSpec.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbLegacySerializationJournalSpec : JournalSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbLegacySerializationJournalSpec : JournalSpec
     {
         protected override bool SupportsRejectingNonSerializableObjects { get; } = false;
 

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationSnapshotStoreSpec.cs
@@ -13,7 +13,7 @@ namespace Akka.Persistence.MongoDb.Tests
 {
     // TODO: enable this spec once https://github.com/akkadotnet/akka.net/pull/4190 is available via Akka.NET v1.4.0-beta5 or higher
     //[Collection("MongoDbSpec")]
-    //public class MongoDbLegacySerializationSnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<DatabaseFixture>
+    //public class MongoDbLegacySerializationSnapshotStoreSpec : SnapshotStoreSpec
     //{
     //    protected override bool SupportsSerialization => false;
 

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbPersistenceIdsSpec.cs
@@ -24,7 +24,7 @@ using Reactive.Streams;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbPersistenceIdsSpec : Akka.Persistence.TCK.Query.PersistenceIdsSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbPersistenceIdsSpec : Akka.Persistence.TCK.Query.PersistenceIdsSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSpec.cs
@@ -12,7 +12,7 @@ using Akka.Configuration;
 namespace Akka.Persistence.MongoDb.Tests
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbSnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbSnapshotStoreSpec : SnapshotStoreSpec
     {
         public MongoDbSnapshotStoreSpec(DatabaseFixture databaseFixture) : base(CreateSpecConfig(databaseFixture), "MongoDbSnapshotStoreSpec")
         {

--- a/src/Akka.Persistence.MongoDb.Tests/Serialization/MongoDbJournalSerializationSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Serialization/MongoDbJournalSerializationSpec.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.MongoDb.Tests.Serialization
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbJournalSerializationSpec : JournalSerializationSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbJournalSerializationSpec : JournalSerializationSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/Akka.Persistence.MongoDb.Tests/Serialization/MongoDbSnapshotStoreSerializationSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Serialization/MongoDbSnapshotStoreSerializationSpec.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 namespace Akka.Persistence.MongoDb.Tests.Serialization
 {
     [Collection("MongoDbSpec")]
-    public class MongoDbSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec, IClassFixture<DatabaseFixture>
+    public class MongoDbSnapshotStoreSerializationSpec : SnapshotStoreSerializationSpec
     {
         public static readonly AtomicCounter Counter = new AtomicCounter(0);
         private readonly ITestOutputHelper _output;

--- a/src/common.props
+++ b/src/common.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.8.3</TestSdkVersion>
+    <TestSdkVersion>16.9.1</TestSdkVersion>
     <AkkaVersion>1.4.16</AkkaVersion>
     <FluentAssertionsVersion>4.14.0</FluentAssertionsVersion>
   </PropertyGroup>


### PR DESCRIPTION
Ensure that both the journal and the metadata collection are updated in the same transaction. Either both succeed or neither do.