### PR TITLE
Fix auto-initialize default value in default configuration

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Persistence.MongoDb.Tests
             var mongoPersistence = MongoDbPersistence.Get(Sys);
 
             mongoPersistence.SnapshotStoreSettings.ConnectionString.Should().Be(string.Empty);
-            mongoPersistence.SnapshotStoreSettings.AutoInitialize.Should().BeFalse();
+            mongoPersistence.SnapshotStoreSettings.AutoInitialize.Should().BeTrue();
             mongoPersistence.SnapshotStoreSettings.Collection.Should().Be("SnapshotStore");
             mongoPersistence.SnapshotStoreSettings.LegacySerialization.Should().BeFalse();
         }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSettingsSpec.cs
@@ -19,7 +19,7 @@ namespace Akka.Persistence.MongoDb.Tests
             var mongoPersistence = MongoDbPersistence.Get(Sys);
 
             mongoPersistence.JournalSettings.ConnectionString.Should().Be(string.Empty);
-            mongoPersistence.JournalSettings.AutoInitialize.Should().BeFalse();
+            mongoPersistence.JournalSettings.AutoInitialize.Should().BeTrue();
             mongoPersistence.JournalSettings.Collection.Should().Be("EventJournal");
             mongoPersistence.JournalSettings.MetadataCollection.Should().Be("Metadata");
             mongoPersistence.JournalSettings.LegacySerialization.Should().BeFalse();

--- a/src/Akka.Persistence.MongoDb/reference.conf
+++ b/src/Akka.Persistence.MongoDb/reference.conf
@@ -37,7 +37,7 @@
 			connection-string = ""
 
 			# should corresponding snapshot's indexes be initialized automatically
-			auto-initialize = off
+			auto-initialize = on
 
 			# dispatcher used to drive snapshot storage actor
 			plugin-dispatcher = "akka.actor.default-dispatcher"

--- a/src/Akka.Persistence.MongoDb/reference.conf
+++ b/src/Akka.Persistence.MongoDb/reference.conf
@@ -8,7 +8,7 @@
 			connection-string = ""
 
 			# should corresponding journal table's indexes be initialized automatically
-			auto-initialize = off
+			auto-initialize = on
 
 			# dispatcher used to drive journal actor
 			plugin-dispatcher = "akka.actor.default-dispatcher"


### PR DESCRIPTION
Default HOCON auto-initialize value should be on, else indexes would not be built on new projects and will break recovery