### PR TITLE
Bump `build.fsx` to also target .NET 6.0 for tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -52,7 +52,7 @@ let outputBinariesNet = outputBinaries @@ "net5.0"
 // Configuration values for tests
 let testNetFrameworkVersion = "net471"
 let testNetCoreVersion = "netcoreapp3.1"
-let testNetVersion = "net5.0"
+let testNetVersion = "net6.0"
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"


### PR DESCRIPTION
Needed to bump `build.fsx` to also target .NET 6