### PR TITLE
Make DatabaseFixture use a single node  replica set

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/DatabaseFixture.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/DatabaseFixture.cs
@@ -18,7 +18,7 @@ namespace Akka.Persistence.MongoDb.Tests
 
         public DatabaseFixture()
         {
-            _runner = MongoDbRunner.Start();
+            _runner = MongoDbRunner.Start(singleNodeReplSet: true);
             ConnectionString = _runner.ConnectionString + "akkanet";
         }
 


### PR DESCRIPTION
Fixes #298 

## Changes

Changed `DatabaseFixture` to use a single node replica set