### PR TITLE
[upgrade] MongoDB.Driver from 2.18.0 to 2.19.0

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -18,14 +18,14 @@ jobs:
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
       - task: UseDotNet@2
-        displayName: 'Use .NET 6 SDK 6.0.100'
+        displayName: 'Use .NET 6 SDK 6.0.407'
         inputs:
-          version: 6.0.100
+          version: 6.0.407
       - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3.1.10'
+        displayName: 'Use .NET Core Runtime 3.1.32'
         inputs:
           packageType: runtime
-          version: 3.1.10
+          version: 3.1.32
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build-system/linux-pr-validation.yaml
+++ b/build-system/linux-pr-validation.yaml
@@ -24,8 +24,8 @@ jobs:
 
   - template: azure-pipeline.template.yaml
     parameters:
-      name: 'net_5_tests_linux'
-      displayName: '.NET 5 Unit Tests (Linux)'
+      name: 'net_6_tests_linux'
+      displayName: '.NET 6 Unit Tests (Linux)'
       vmImage: 'ubuntu-latest'
       scriptFileName: ./build.sh
       scriptArgs: runTestsNet

--- a/build-system/windows-pr-validation.yaml
+++ b/build-system/windows-pr-validation.yaml
@@ -32,8 +32,8 @@ jobs:
 
   - template: azure-pipeline.template.yaml
     parameters:
-      name: 'net_5_tests_windows'
-      displayName: '.NET 5 Unit Tests (Windows)'
+      name: 'net_6_tests_windows'
+      displayName: '.NET 6 Unit Tests (Windows)'
       vmImage: 'windows-latest'
       scriptFileName: build.cmd
       scriptArgs: runTestsNet

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -23,9 +23,9 @@ variables:
     value: akkadotnet/Akka.Persistence.MongoDB
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET 6 SDK 6.0.100'
+  displayName: 'Use .NET 6 SDK 6.0.407'
   inputs:
-    version: 6.0.100
+    version: 6.0.407
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSetupSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSetupSpec.cs
@@ -10,6 +10,7 @@ using Akka.Persistence.TCK.Journal;
 using Akka.Persistence.TCK.Serialization;
 using Akka.TestKit;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,8 +31,11 @@ namespace Akka.Persistence.MongoDb.Tests
 
         private static ActorSystemSetup CreateBootstrapSetup(DatabaseFixture fixture)
         {
+            //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
             var connectionString = new MongoUrl(fixture.ConnectionString);
-            var client = new MongoClient(connectionString);
+            var clientSettings = MongoClientSettings.FromUrl(connectionString);
+            clientSettings.LinqProvider = LinqProvider.V2;
+            var client = new MongoClient(clientSettings);
             var databaseName = connectionString.DatabaseName;
             var settings = client.Settings;
 

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSetupSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSetupSpec.cs
@@ -4,6 +4,7 @@ using Akka.Configuration;
 using Akka.Persistence.TCK.Journal;
 using Akka.Persistence.TCK.Snapshot;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,8 +25,11 @@ namespace Akka.Persistence.MongoDb.Tests
 
         private static ActorSystemSetup CreateBootstrapSetup(DatabaseFixture fixture)
         {
+            //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
             var connectionString = new MongoUrl(fixture.ConnectionString);
-            var client = new MongoClient(connectionString);
+            var clientSettings = MongoClientSettings.FromUrl(connectionString);
+            clientSettings.LinqProvider = LinqProvider.V2;
+            var client = new MongoClient(clientSettings);
             var databaseName = connectionString.DatabaseName;
             var settings = client.Settings;
 

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageReference Include="akka.streams" Version="$(AkkaVersion)" />
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -68,9 +68,11 @@ namespace Akka.Persistence.MongoDb.Journal
                     client = new MongoClient(setupOption.Value.JournalConnectionSettings);
                     return client.GetDatabase(setupOption.Value.JournalDatabaseName);
                 }
-
+                //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
                 var connectionString = new MongoUrl(_settings.ConnectionString);
-                client = new MongoClient(connectionString);
+                var clientSettings = MongoClientSettings.FromUrl(connectionString);
+                clientSettings.LinqProvider = LinqProvider.V2;
+                client = new MongoClient(clientSettings);
                 return client.GetDatabase(connectionString.DatabaseName);
             });
             _journalCollection = new Lazy<IMongoCollection<JournalEntry>>(() =>

--- a/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
@@ -12,6 +12,7 @@ using Akka.Configuration;
 using Akka.Persistence.Snapshot;
 using Akka.Util;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace Akka.Persistence.MongoDb.Snapshot
 {
@@ -47,8 +48,11 @@ namespace Akka.Persistence.MongoDb.Snapshot
                 var setupOption = Context.System.Settings.Setup.Get<MongoDbPersistenceSetup>();
                 if (!setupOption.HasValue || setupOption.Value.SnapshotConnectionSettings == null)
                 {
+                    //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
                     var connectionString = new MongoUrl(_settings.ConnectionString);
-                    client = new MongoClient(connectionString);
+                    var clientSettings = MongoClientSettings.FromUrl(connectionString);
+                    clientSettings.LinqProvider = LinqProvider.V2;
+                    client = new MongoClient(clientSettings);
                     snapshot = client.GetDatabase(connectionString.DatabaseName);
                 }
                 else

--- a/src/common.props
+++ b/src/common.props
@@ -21,7 +21,7 @@
 
     <XunitVersion>2.4.2</XunitVersion>
     <TestSdkVersion>17.5.0</TestSdkVersion>
-    <AkkaVersion>1.5.0</AkkaVersion>
+    <AkkaVersion>1.5.1</AkkaVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -21,7 +21,7 @@
 
     <XunitVersion>2.4.2</XunitVersion>
     <TestSdkVersion>17.5.0</TestSdkVersion>
-    <AkkaVersion>1.5.1</AkkaVersion>
+    <AkkaVersion>1.5.0</AkkaVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/306

## Changes

Default `LinqProvider` has been changed to `LINQ3.LinqProvider` can be changed back to LINQ2 - @Aaronontheweb 

