### PR TITLE
Update RELEASE_NOTES.md for 1.5.12 release 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
-#### 1.5.9 Date TBC ####
-* [Bump Akka.NET to 1.5.9](TBC)
-* [Bump XunitVersion from 2.4.2 to 2.5.0 ](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/332)
+#### 1.5.12 August 10 2023 ####
+
+* [Bump Akka.Persistence.Hosting from 1.5.8.1 to 1.5.12](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/337)
+* [Bump AkkaVersion from 1.5.11 to 1.5.12](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/336)
+* [Separate Akka.Hosting and core Akka version](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/335)
+* [Bump XunitVersion from 2.4.2 to 2.5.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/332)
 * [Move to using Build Props file and central package management.](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/333)
 * [Bump MongoDB.Driver from 2.19.1 to 2.20.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/326)
 * [Adding Hosting Extensions for Akka.Persistence.MongoDB](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/331)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.5.9 Date TBC ####
+* [Bump Akka.NET to 1.5.9](TBC)
+* [Bump XunitVersion from 2.4.2 to 2.5.0 ](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/332)
+* [Move to using Build Props file and central package management.](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/333)
+* [Bump MongoDB.Driver from 2.19.1 to 2.20.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/326)
+* [Adding Hosting Extensions for Akka.Persistence.MongoDB](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/331)
+ 
 #### 1.5.8 June 30 2023 ####
 
 * [Bump Akka.NET to 1.5.8](https://github.com/akkadotnet/akka.net/releases/tag/1.5.8)


### PR DESCRIPTION
The starting point for the 1.5.12 release notes

To match the notes would require these two pr's to be merged
* https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/337
* https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/336