### PR TITLE
Revert MongoDb.Driver version to 2.18.0

### DIFF
--- a/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
+++ b/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.MongoDb
         /// <summary>
         /// Initializes a new instance of the <see cref="FullTypeNameObjectSerializer"/> class.
         /// </summary>
-        public FullTypeNameObjectSerializer() : base(FullTypeNameDiscriminatorConvention.Instance, AllAllowedTypes) { }
+        public FullTypeNameObjectSerializer() : base(FullTypeNameDiscriminatorConvention.Instance) { }
 
         /// <summary>
         /// Deserializes a value.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion) " />
     <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Streams" Version="$(AkkaVersion) " />
-    <PackageVersion Include="MongoDB.Driver" Version="2.20.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.18.0" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Revert MongoDb.Driver version to 2.18.0 while preserving all new changes