### PR TITLE
Fix missing symbol package upload

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -32,7 +32,7 @@ steps:
     TEST_ENVIRONMENT: "CICD"
   inputs:
     filename: build.cmd
-    arguments: 'nuget nugetpublishurl=https://www.nuget.org/api/v2/package nugetkey=$(nugetKey)'
+    arguments: 'nuget nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(nugetKey)'
 
 - task: GitHubRelease@0
   displayName: 'GitHub release (create)'

--- a/build.fsx
+++ b/build.fsx
@@ -284,38 +284,40 @@ Target "CreateNuget" (fun _ ->
                 { p with
                     Project = project
                     Configuration = configuration
-                    AdditionalArgs = ["--include-symbols --no-build"]
+                    AdditionalArgs = ["--no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg"]
                     VersionSuffix = overrideVersionSuffix project
-                    OutputPath = outputNuGet })
+                    OutputPath = "\"" + outputNuGet + "\"" })
 
     projects |> Seq.iter (runSingleProject)
 )
 
 Target "PublishNuget" (fun _ ->
-    let projects = !! "./bin/nuget/*.nupkg" -- "./bin/nuget/*.symbols.nupkg"
-    let apiKey = getBuildParamOrDefault "nugetkey" ""
-    let source = getBuildParamOrDefault "nugetpublishurl" ""
-    let symbolSource = getBuildParamOrDefault "symbolspublishurl" ""
-    let shouldPublishSymbolsPackages = not (symbolSource = "")
-
-    if (not (source = "") && not (apiKey = "") && shouldPublishSymbolsPackages) then
-        let runSingleProject project =
-            DotNetCli.RunCommand
-                (fun p -> 
-                    { p with 
-                        TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "nuget push %s --api-key %s --source %s --symbol-source %s" project apiKey source symbolSource)
-
-        projects |> Seq.iter (runSingleProject)
-    else if (not (source = "") && not (apiKey = "") && not shouldPublishSymbolsPackages) then
-        let runSingleProject project =
-            DotNetCli.RunCommand
-                (fun p -> 
-                    { p with 
-                        TimeOut = TimeSpan.FromMinutes 10. })
-                (sprintf "nuget push %s --api-key %s --source %s" project apiKey source)
-
-        projects |> Seq.iter (runSingleProject)
+    let shouldPushNugetPackages = hasBuildParam "nugetkey"
+    if not shouldPushNugetPackages then ()
+    else
+        let apiKey = getBuildParam "nugetkey"
+        let sourceUrl = getBuildParamOrDefault "nugetpublishurl" "https://api.nuget.org/v3/index.json"
+        
+        let rec publishPackage retryLeft packageFile =
+            tracefn "Pushing %s Attempts left: %d" (FullName packageFile) retryLeft
+            let tracing = ProcessHelper.enableProcessTracing
+            try
+                try
+                    ProcessHelper.enableProcessTracing <- false
+                    DotNetCli.RunCommand
+                        (fun p ->
+                            { p with
+                                TimeOut = TimeSpan.FromMinutes 10. })
+                        (sprintf "nuget push %s --api-key %s --source %s --no-service-endpoint" packageFile apiKey sourceUrl)
+                with exn ->
+                    if (retryLeft > 0) then (publishPackage (retryLeft-1) packageFile)
+            finally
+                ProcessHelper.enableProcessTracing <- tracing
+                
+        printfn "Pushing nuget packages"
+        let normalPackages = !! (outputNuGet @@ "*.nupkg") |> Seq.sortBy(fun x -> x.ToLower())
+        for package in normalPackages do
+            publishPackage 3 package
 )
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
Tested using local BaGet installation

```
Starting Target: PublishNuget (==> SignPackages)
Pushing nuget packages
Pushing D:\git\akkadotnet\Akka.Persistence.MongoDB\bin\nuget\Akka.Persistence.MongoDb.1.5.12.1.nupkg Attempts left: 3
Pushing Akka.Persistence.MongoDb.1.5.12.1.nupkg to 'https://localhost:5001/api/v2/package'...
  PUT https://localhost:5001/api/v2/package/
  Created https://localhost:5001/api/v2/package/ 695ms
Your package was pushed.
Pushing Akka.Persistence.MongoDb.1.5.12.1.snupkg to 'https://localhost:5001/api/v2/symbol'...
  PUT https://localhost:5001/api/v2/symbol/
  Created https://localhost:5001/api/v2/symbol/ 121ms
Your package was pushed.
Pushing D:\git\akkadotnet\Akka.Persistence.MongoDB\bin\nuget\Akka.Persistence.MongoDb.Hosting.1.5.12.1.nupkg Attempts left: 3
Pushing Akka.Persistence.MongoDb.Hosting.1.5.12.1.nupkg to 'https://localhost:5001/api/v2/package'...
  PUT https://localhost:5001/api/v2/package/
  Created https://localhost:5001/api/v2/package/ 103ms
Your package was pushed.
Pushing Akka.Persistence.MongoDb.Hosting.1.5.12.1.snupkg to 'https://localhost:5001/api/v2/symbol'...
  PUT https://localhost:5001/api/v2/symbol/
  Created https://localhost:5001/api/v2/symbol/ 7ms
Your package was pushed.
Finished Target: PublishNuget
```

## Changes

* Add package upload retry
* Fix nuget publish script to upload .snupkg files

