### PR TITLE
Fix the failure in the CurrentEventsByTag query when there are no events

### DIFF
--- a/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
@@ -225,7 +225,7 @@ namespace Akka.Persistence.MongoDb.Query
         protected override void ReceiveRecoverySuccess(long highestSequenceNr)
         {
             Buffer.DeliverBuffer(TotalDemand);
-            if (highestSequenceNr < ToOffset)
+            if (highestSequenceNr > 0 && highestSequenceNr < ToOffset)
                 _toOffset = highestSequenceNr;
 
             if (Buffer.IsEmpty && CurrentOffset > ToOffset)


### PR DESCRIPTION
Fixes #373

## Changes

Updated [CurrentEventsByTagPublisher](https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/6c530d89e4560404424f16970d12a2d76e2c44dc/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs#L201) to check if the recovery sequence number is greater than 0 before assigning to `ToOffset` because it must have a positive value; otherwise, [ReplayTaggedMessages](https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/dev/src/Akka.Persistence.MongoDb/Query/QueryApi.cs#L371) will throw `ArgumentException`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #373 
* [x] Changes in public API reviewed, if any.

### Latest `dev` Benchmarks 

I did not run any benchmarks.
