### PR TITLE
Fix CurrentEventsByTag never completes

### DIFF
--- a/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
@@ -128,7 +128,7 @@ namespace Akka.Persistence.MongoDb.Query
                             @event: replayed.Persistent.Payload,
                             tags: new [] { replayed.Tag }));
 
-                        CurrentOffset = replayed.Offset;
+                        CurrentOffset = replayed.Offset + 1;
                         Buffer.DeliverBuffer(TotalDemand);
                         break;
                     case RecoverySuccess success:

--- a/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
@@ -128,7 +128,7 @@ namespace Akka.Persistence.MongoDb.Query
                             @event: replayed.Persistent.Payload,
                             tags: new [] { replayed.Tag }));
 
-                        CurrentOffset = replayed.Offset + 1;
+                        CurrentOffset = replayed.Offset;
                         Buffer.DeliverBuffer(TotalDemand);
                         break;
                     case RecoverySuccess success:
@@ -216,7 +216,7 @@ namespace Akka.Persistence.MongoDb.Query
         protected override void ReceiveIdleRequest()
         {
             Buffer.DeliverBuffer(TotalDemand);
-            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+            if (Buffer.IsEmpty && CurrentOffset >= ToOffset)
                 OnCompleteThenStop();
             else
                 Self.Tell(EventsByTagPublisher.Continue.Instance);
@@ -228,7 +228,7 @@ namespace Akka.Persistence.MongoDb.Query
             if (highestSequenceNr > 0 && highestSequenceNr < ToOffset)
                 _toOffset = highestSequenceNr;
 
-            if (Buffer.IsEmpty && CurrentOffset > ToOffset)
+            if (Buffer.IsEmpty && (CurrentOffset >= ToOffset || CurrentOffset == FromOffset))
                 OnCompleteThenStop();
             else
                 Self.Tell(EventsByTagPublisher.Continue.Instance);


### PR DESCRIPTION
Observed after upgrading to Akka 1.5.26, CurrentEventsByTag never completes due to an off by 1 error.

The regression test for this is `Bug61_Events_Recovered_By_Id_Should_Match_Tag`
