### PR TITLE
Update RELEASE_NOTES.md for 1.5.26 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 1.5.26 July 15th 2024 ####
+
+* [Bump Akka.NET to 1.5.26](https://github.com/akkadotnet/akka.net/releases/tag/1.5.26)
+* [Bump Akka.Persistence.Hosting to 1.5.25](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.25)
+* [Fix failure in CurrentEventByTag when there are no events](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/374)
+* [Fix CurrentEventByTag never completes](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/379)
+
 #### 1.5.12.1 September 15 2023 ####
 
 * [Bump Akka.Persistence.Hosting to 1.5.12.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12.1)


### PR DESCRIPTION
## 1.5.26 July 15th 2024

* [Bump Akka.NET to 1.5.26](https://github.com/akkadotnet/akka.net/releases/tag/1.5.26)
* [Bump Akka.Persistence.Hosting to 1.5.25](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.25)
* [Fix failure in CurrentEventByTag when there are no events](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/374)
* [Fix CurrentEventByTag never completes](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/379)