### PR TITLE
Bump AkkaVersion and AkkaHostingVersion from 1.5.28 to 1.5.29

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MongoDbVersion>2.28.0</MongoDbVersion>
-    <AkkaVersion>1.5.28</AkkaVersion>
-    <AkkaHostingVersion>1.5.28</AkkaHostingVersion>
+    <AkkaVersion>1.5.29</AkkaVersion>
+    <AkkaHostingVersion>1.5.29</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
> [!NOTE]
>
> Need to wait for Akka.Hosting 1.5.29 to be released on NuGet.org before passing CI/CD