### PR TITLE
Update RELEASE_NOTES.md for 1.5.30 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.5.30 October 1st 2024 ####
+#### 1.5.30 October 3rd 2024 ####
 
 * [Bump Akka.NET to 1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
 * [Bump Akka.Persistence.Hosting to 1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,20 @@
+#### 1.5.30 October 1st 2024 ####
+
+* [Bump Akka.NET to 1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
+* [Bump Akka.Persistence.Hosting to 1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)
+* [Bump MongoDB.Driver to 2.28.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/388)
+
+**Breaking Change Notice**
+
+The MongoDb driver 2.28.0 is [now strongly-named](https://github.com/mongodb/mongo-csharp-driver/pull/1393) which may affect your project(s). You can read more about this decision [here](https://www.mongodb.com/community/forums/t/net-c-driver-strong-naming/291649).
+
 #### 1.5.29 October 1st 2024 ####
+
+> [!NOTE]
+> 
+> **Deprecated**
+> 
+> Deprecated due to Akka.NET 1.5.29 deprecation. Please use 1.5.30 instead.
 
 * [Bump Akka.NET to 1.5.29](https://github.com/akkadotnet/akka.net/releases/tag/1.5.29)
 * [Bump Akka.Persistence.Hosting to 1.5.29](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.29)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MongoDbVersion>2.28.0</MongoDbVersion>
-    <AkkaVersion>1.5.29</AkkaVersion>
-    <AkkaHostingVersion>1.5.29</AkkaHostingVersion>
+    <AkkaVersion>1.5.30</AkkaVersion>
+    <AkkaHostingVersion>1.5.30</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
## 1.5.30 October 1st 2024

* [Bump Akka.NET to 1.5.30](https://github.com/akkadotnet/akka.net/releases/tag/1.5.30)
* [Bump Akka.Persistence.Hosting to 1.5.30](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.30)
* [Bump MongoDB.Driver to 2.28.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/388)

**Breaking Change Notice**

The MongoDb driver 2.28.0 is [now strongly-named](https://github.com/mongodb/mongo-csharp-driver/pull/1393) which may affect your project(s). You can read more about this decision [here](https://www.mongodb.com/community/forums/t/net-c-driver-strong-naming/291649).