### PR TITLE
Bump MongoDb.Driver to 3.0.0

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -18,9 +18,9 @@ jobs:
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
       - task: UseDotNet@2
-        displayName: 'Use .NET 7 SDK 7'
+        displayName: 'Use .NET SDK 8'
         inputs:
-          version: 7.x
+          version: 8.x
       - task: UseDotNet@2
         displayName: 'Use .NET Core Runtime 3'
         inputs:

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -22,10 +22,10 @@ jobs:
         inputs:
           version: 8.x
       - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3'
+        displayName: 'Use .NET SDK 7'
         inputs:
           packageType: runtime
-          version: 3.x
+          version: 7.x
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build-system/linux-pr-validation.yaml
+++ b/build-system/linux-pr-validation.yaml
@@ -16,14 +16,6 @@ pr:
 jobs:
   - template: azure-pipeline.template.yaml
     parameters:
-      name: 'net_core_tests_linux'
-      displayName: '.NET Core Unit Tests (Linux)'
-      vmImage: 'ubuntu-latest'
-      scriptFileName: ./build.sh
-      scriptArgs: runTestsNetCore
-
-  - template: azure-pipeline.template.yaml
-    parameters:
       name: 'net_7_tests_linux'
       displayName: '.NET 7 Unit Tests (Linux)'
       vmImage: 'ubuntu-latest'

--- a/build-system/windows-pr-validation.yaml
+++ b/build-system/windows-pr-validation.yaml
@@ -24,14 +24,6 @@ jobs:
 
   - template: azure-pipeline.template.yaml
     parameters:
-      name: 'net_core_tests_windows'
-      displayName: '.NET Core Unit Tests (Windows)'
-      vmImage: 'windows-latest'
-      scriptFileName: build.cmd
-      scriptArgs: runTestsNetCore
-
-  - template: azure-pipeline.template.yaml
-    parameters:
       name: 'net_7_tests_windows'
       displayName: '.NET 7 Unit Tests (Windows)'
       vmImage: 'windows-latest'

--- a/build.fsx
+++ b/build.fsx
@@ -94,6 +94,7 @@ Target "BuildNet" (fun _ ->
                   -- "./src/examples/**/*.csproj"
         | _ -> !! "./src/**/*.csproj" // if you need to filter specs for Linux vs. Windows, do it here
                -- "./src/**/*.Tests.csproj"
+               -- "./src/examples/**/*.csproj"
 
     let tests =
         match (isWindows) with 

--- a/build.fsx
+++ b/build.fsx
@@ -45,13 +45,13 @@ let outputTests = __SOURCE_DIRECTORY__ @@ "TestResults"
 let outputPerfTests = __SOURCE_DIRECTORY__ @@ "PerfResults"
 let outputBinaries = output @@ "binaries"
 let outputNuGet = output @@ "nuget"
-let outputBinariesNet45 = outputBinaries @@ "net45"
-let outputBinariesNetStandard = outputBinaries @@ "netstandard2.0"
-let outputBinariesNet = outputBinaries @@ "net5.0"
+
+// Configuration values for builds
+let buildNetFrameworkVersion = "net472"
+let buildNetVersion = "netstandard2.1"
 
 // Configuration values for tests
-let testNetFrameworkVersion = "net471"
-let testNetCoreVersion = "netcoreapp3.1"
+let testNetFrameworkVersion = "net472"
 let testNetVersion = "net7.0"
 
 Target "Clean" (fun _ ->
@@ -61,9 +61,6 @@ Target "Clean" (fun _ ->
     CleanDir outputTests
     CleanDir outputPerfTests
     CleanDir outputNuGet
-    CleanDir outputBinariesNet45
-    CleanDir outputBinariesNetStandard
-    CleanDir outputBinariesNet
     CleanDir "docs/_site"
 
     CleanDirs !! "./**/bin"
@@ -85,6 +82,47 @@ Target "Build" (fun _ ->
                 AdditionalArgs = additionalArgs }) // "Rebuild"  
 )
 
+// Build target that only builds netstandard2.1 library and net7.0 test projects
+// Intended for build platforms that does not support .NET Framework (eg. Linux/MAC) 
+Target "BuildNet" (fun _ ->
+    let additionalArgs = if versionSuffix.Length > 0 then [sprintf "/p:VersionSuffix=%s" versionSuffix] else []
+        
+    let projects = 
+        match (isWindows) with 
+        | true -> !! "./src/**/*.csproj"
+                  -- "./src/**/*.Tests.csproj"
+                  -- "./src/examples/**/*.csproj"
+        | _ -> !! "./src/**/*.csproj" // if you need to filter specs for Linux vs. Windows, do it here
+               -- "./src/**/*.Tests.csproj"
+
+    let tests =
+        match (isWindows) with 
+        | true -> !! "./src/**/*.Tests.csproj"
+        | _ -> !! "./src/**/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
+    
+    let compileSingleProject project =
+        DotNetCli.Build
+            (fun p -> 
+                { p with
+                    Project = project
+                    Configuration = configuration
+                    Framework =  buildNetVersion
+                    AdditionalArgs = additionalArgs }) // "Rebuild"
+
+    let compileSingleTest project =
+        DotNetCli.Build
+            (fun p -> 
+                { p with
+                    Project = project
+                    Configuration = configuration
+                    Framework =  testNetVersion
+                    AdditionalArgs = additionalArgs }) // "Rebuild"
+            
+    projects |> Seq.iter (log)
+    projects |> Seq.iter (compileSingleProject)
+    tests |> Seq.iter (log)
+    tests |> Seq.iter (compileSingleTest)
+)
 
 //--------------------------------------------------------------------------------
 // Tests targets 
@@ -96,7 +134,6 @@ type Runtime =
 
 let getTestAssembly runtime project =
     let assemblyPath = match runtime with
-                        | NetCore -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetCoreVersion @@ fileNameWithoutExt project + ".dll")
                         | NetFramework -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetFrameworkVersion @@ fileNameWithoutExt project + ".dll")
                         | Net -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetVersion @@ fileNameWithoutExt project + ".dll")
 
@@ -134,30 +171,6 @@ Target "RunTests" (fun _ ->
             match (hasTeamCity) with
             | true -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s --results-directory %s -- -parallel none -teamcity" testNetFrameworkVersion outputTests)
             | false -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s --results-directory %s -- -parallel none" testNetFrameworkVersion outputTests)
-
-        let result = ExecProcess(fun info ->
-            info.FileName <- "dotnet"
-            info.WorkingDirectory <- (Directory.GetParent project).FullName
-            info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
-        
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result  
-
-    CreateDir outputTests
-    projects |> Seq.iter (log)
-    projects |> Seq.iter (runSingleProject)
-)
-
-Target "RunTestsNetCore" (fun _ ->
-    let projects = 
-        match (isWindows) with 
-        | true -> !! "./src/**/*.Tests.csproj"
-        | _ -> !! "./src/**/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
-
-    let runSingleProject project =
-        let arguments =
-            match (hasTeamCity) with
-            | true -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s --results-directory %s -- -parallel none -teamcity" testNetCoreVersion outputTests)
-            | false -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s --results-directory %s -- -parallel none" testNetCoreVersion outputTests)
 
         let result = ExecProcess(fun info ->
             info.FileName <- "dotnet"
@@ -380,15 +393,13 @@ Target "BuildRelease" DoNothing
 Target "All" DoNothing
 Target "Nuget" DoNothing
 Target "RunTestsFull" DoNothing
-Target "RunTestsNetCoreFull" DoNothing
 
 // build dependencies
 "Clean" ==> "AssemblyInfo" ==> "Build" ==> "BuildRelease"
 
 // tests dependencies
 "Build" ==> "RunTests"
-"Build" ==> "RunTestsNetCore"
-"Build" ==> "RunTestsNet"
+"AssemblyInfo" ==> "BuildNet" ==> "RunTestsNet"
 "Build" ==> "NBench"
 
 // nuget dependencies
@@ -401,7 +412,6 @@ Target "RunTestsNetCoreFull" DoNothing
 // all
 "BuildRelease" ==> "All"
 "RunTests" ==> "All"
-"RunTestsNetCore" ==> "All"
 "RunTestsNet" ==> "All"
 "NBench" ==> "All"
 "Nuget" ==> "All"

--- a/src/Akka.Persistence.MongoDb.Hosting/Akka.Persistence.MongoDb.Hosting.csproj
+++ b/src/Akka.Persistence.MongoDb.Hosting/Akka.Persistence.MongoDb.Hosting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetFrameworkLibVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSetupSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbJournalSetupSpec.cs
@@ -31,10 +31,8 @@ namespace Akka.Persistence.MongoDb.Tests
 
         private static ActorSystemSetup CreateBootstrapSetup(DatabaseFixture fixture)
         {
-            //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
             var connectionString = new MongoUrl(fixture.ConnectionString);
             var clientSettings = MongoClientSettings.FromUrl(connectionString);
-            clientSettings.LinqProvider = LinqProvider.V2;
             var client = new MongoClient(clientSettings);
             var databaseName = connectionString.DatabaseName;
             var settings = client.Settings;

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSetupSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbSnapshotStoreSetupSpec.cs
@@ -1,10 +1,8 @@
 ﻿using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
-using Akka.Persistence.TCK.Journal;
 using Akka.Persistence.TCK.Snapshot;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,10 +23,8 @@ namespace Akka.Persistence.MongoDb.Tests
 
         private static ActorSystemSetup CreateBootstrapSetup(DatabaseFixture fixture)
         {
-            //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
             var connectionString = new MongoUrl(fixture.ConnectionString);
             var clientSettings = MongoClientSettings.FromUrl(connectionString);
-            clientSettings.LinqProvider = LinqProvider.V2;
             var client = new MongoClient(clientSettings);
             var databaseName = connectionString.DatabaseName;
             var settings = client.Settings;

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetFrameworkLibVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +10,5 @@
     <PackageReference Include="Akka.Persistence.Query" />
     <PackageReference Include="Akka.Streams" />
     <PackageReference Include="MongoDB.Driver" />
-    <PackageReference Include="MongoDB.Driver.GridFS" />
   </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
+++ b/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
@@ -17,15 +17,20 @@ namespace Akka.Persistence.MongoDb
     /// <summary>
     /// Represents a serializer for objects.
     /// </summary>
-    class FullTypeNameObjectSerializer : ObjectSerializer
+    class FullTypeNameObjectSerializer : ClassSerializerBase<object>, IHasDiscriminatorConvention
     {
-        protected readonly IDiscriminatorConvention DiscriminatorConvention = FullTypeNameDiscriminatorConvention.Instance;
-
+        private ObjectSerializer _serializer;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="FullTypeNameObjectSerializer"/> class.
         /// </summary>
-        public FullTypeNameObjectSerializer() : base(FullTypeNameDiscriminatorConvention.Instance, AllAllowedTypes) { }
+        public FullTypeNameObjectSerializer()
+        {
+            _serializer = new ObjectSerializer(DiscriminatorConvention, ObjectSerializer.AllAllowedTypes);
+        }
 
+        public IDiscriminatorConvention DiscriminatorConvention => FullTypeNameDiscriminatorConvention.Instance;
+        
         /// <summary>
         /// Deserializes a value.
         /// </summary>
@@ -38,7 +43,7 @@ namespace Akka.Persistence.MongoDb
                 RegisterNewTypesToDiscriminator(DiscriminatorConvention.GetActualType(bsonReader, typeof(object)));
             }
 
-            return base.Deserialize(context, args);
+            return _serializer.Deserialize(context, args);
         }
 
         /// <summary>
@@ -52,14 +57,14 @@ namespace Akka.Persistence.MongoDb
                 RegisterNewTypesToDiscriminator(value.GetType());
             }
 
-            base.Serialize(context, args, value);
+            _serializer.Serialize(context, args, value);
         }
 
         /// <summary>
         /// If the type is not registered, attach it to our discriminator
         /// </summary>
         /// <param name="actualType">the type to examine</param>
-        protected void RegisterNewTypesToDiscriminator(Type actualType)
+        private void RegisterNewTypesToDiscriminator(Type actualType)
         {
             // we've detected a new concrete type that isn't registered in MongoDB's serializer
             if (actualType != typeof(object) && !actualType.GetTypeInfo().IsInterface && !BsonSerializer.IsTypeDiscriminated(actualType))

--- a/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
+++ b/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
@@ -17,9 +17,9 @@ namespace Akka.Persistence.MongoDb
     /// <summary>
     /// Represents a serializer for objects.
     /// </summary>
-    class FullTypeNameObjectSerializer : ClassSerializerBase<object>, IHasDiscriminatorConvention
+    internal class FullTypeNameObjectSerializer : ClassSerializerBase<object>, IHasDiscriminatorConvention
     {
-        private ObjectSerializer _serializer;
+        private readonly ObjectSerializer _serializer;
         
         /// <summary>
         /// Initializes a new instance of the <see cref="FullTypeNameObjectSerializer"/> class.

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -74,11 +74,8 @@ namespace Akka.Persistence.MongoDb.Journal
                 return _mongoDatabase_DoNotUseDirectly;
             }
 
-            //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
             var connectionString = new MongoUrl(_settings.ConnectionString);
             var clientSettings = MongoClientSettings.FromUrl(connectionString);
-            clientSettings.LinqProvider = LinqProvider.V2;
-            
             client = new MongoClient(clientSettings);
             _mongoDatabase_DoNotUseDirectly = client.GetDatabase(connectionString.DatabaseName);
             return _mongoDatabase_DoNotUseDirectly;

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournalQueries.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournalQueries.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson;

--- a/src/Akka.Persistence.MongoDb/Snapshot/MongoDbGridFSSnapshotStore.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/MongoDbGridFSSnapshotStore.cs
@@ -78,10 +78,8 @@ public class MongoDbGridFsSnapshotStore : SnapshotStore
         var setupOption = Context.System.Settings.Setup.Get<MongoDbPersistenceSetup>();
         if (!setupOption.HasValue || setupOption.Value.SnapshotConnectionSettings == null)
         {
-            //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
             var connectionString = new MongoUrl(_settings.ConnectionString);
             var clientSettings = MongoClientSettings.FromUrl(connectionString);
-            clientSettings.LinqProvider = LinqProvider.V2;
             client = new MongoClient(clientSettings);
             _mongoDatabase_DoNotUseDirectly = client.GetDatabase(connectionString.DatabaseName);
             return _mongoDatabase_DoNotUseDirectly;

--- a/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
@@ -12,7 +12,6 @@ using Akka.Configuration;
 using Akka.Persistence.Snapshot;
 using Akka.Util;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 
 #nullable enable
 namespace Akka.Persistence.MongoDb.Snapshot
@@ -94,10 +93,8 @@ namespace Akka.Persistence.MongoDb.Snapshot
             var setupOption = Context.System.Settings.Setup.Get<MongoDbPersistenceSetup>();
             if (!setupOption.HasValue || setupOption.Value.SnapshotConnectionSettings == null)
             {
-                //Default LinqProvider has been changed to LINQ3.LinqProvider can be changed back to LINQ2 in the following way:
                 var connectionString = new MongoUrl(_settings.ConnectionString);
                 var clientSettings = MongoClientSettings.FromUrl(connectionString);
-                clientSettings.LinqProvider = LinqProvider.V2;
                 client = new MongoClient(clientSettings);
                 _mongoDatabase_DoNotUseDirectly = client.GetDatabase(connectionString.DatabaseName);
                 return _mongoDatabase_DoNotUseDirectly;
@@ -135,7 +132,7 @@ namespace Akka.Persistence.MongoDb.Snapshot
             base.PostStop();
         }
 
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot?> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             using var unitedCts = CreatePerCallCts();
             var snapshotCollection = await GetSnapshotCollection(unitedCts.Token);
@@ -143,11 +140,12 @@ namespace Akka.Persistence.MongoDb.Snapshot
             return await MaybeWithTransaction(async (session, token) =>
             {
                 var filter = CreateRangeFilter(persistenceId, criteria);
-                return await (session is not null ? snapshotCollection.Find(session, filter) : snapshotCollection.Find(filter)) 
+                var entry = await (session is not null ? snapshotCollection.Find(session, filter) : snapshotCollection.Find(filter)) 
                     .SortByDescending(x => x.SequenceNr)
                     .Limit(1)
-                    .Project(x => ToSelectedSnapshot(x))
                     .FirstOrDefaultAsync(token);
+                
+                return ToSelectedSnapshot(entry);
             }, unitedCts.Token);
         }
 
@@ -272,12 +270,15 @@ namespace Akka.Persistence.MongoDb.Snapshot
                 Snapshot = binary,
                 Timestamp = metadata.Timestamp.Ticks,
                 Manifest = binaryManifest,
-                SerializerId = serializer?.Identifier
+                SerializerId = serializer.Identifier
             };
         }
 
-        private SelectedSnapshot ToSelectedSnapshot(SnapshotEntry entry)
+        private SelectedSnapshot? ToSelectedSnapshot(SnapshotEntry? entry)
         {
+            if (entry is null)
+                return null;
+            
             if (_settings.LegacySerialization)
             {
                 return new SelectedSnapshot(

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,10 +15,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net7.0</NetTestVersion>
-    <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
-    <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
+    <NetFrameworkTestVersion>net472</NetFrameworkTestVersion>
+    <NetStandardLibVersion>netstandard2.1</NetStandardLibVersion>
+    <NetFrameworkLibVersion>net472</NetFrameworkLibVersion>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <MongoDbVersion>2.30.0</MongoDbVersion>
+    <MongoDbVersion>3.0.0</MongoDbVersion>
     <AkkaVersion>1.5.31</AkkaVersion>
     <AkkaHostingVersion>1.5.31.1</AkkaHostingVersion>
   </PropertyGroup>
@@ -11,7 +11,6 @@
     <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Streams" Version="$(AkkaVersion) " />
     <PackageVersion Include="MongoDB.Driver" Version="$(MongoDbVersion)" />
-    <PackageVersion Include="MongoDB.Driver.GridFS" Version="$(MongoDbVersion)" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
@@ -23,7 +22,7 @@
     </PackageVersion>
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="Akka.Persistence.TCK" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Mongo2Go" Version="3.1.3" />
+    <PackageVersion Include="Mongo2Go" Version="4.0.0" />
     <PackageVersion Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->


### PR DESCRIPTION
> [!WARNING]
>
> Breaking changes due to MongoDb.Driver 3.0.0 breaking changes.
> MongoDb.Driver release note: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.0.0
> Upgrade advisory: https://www.mongodb.com/docs/drivers/csharp/v3.0/upgrade/v3/

## Changes

* Bump MongoDb.Driver from 2.30.0 to 3.0.0
* Change target framework from netstandard2.0 to multi-target netstandard2.1 and net472
* Remove MongoDb.Driver.GridFS package reference, its included in the core MongoDb.Driver package now
* Modify FullTypeNameObjectSerializer, `MongoDb.Bson.Serialization.Serializer.ObjectSerializer` is a sealed class now.
* Modify `MongoDbSnapshotStore.LoadAsync()`, MongoDb query `.Project()` only supports expression now.