### PR TITLE
Bump AkkaVersion and AkkaHostingVersion to 1.5.32

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
+++ b/src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj
@@ -9,6 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,14 +2,15 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MongoDbVersion>2.30.0</MongoDbVersion>
-    <AkkaVersion>1.5.31</AkkaVersion>
-    <AkkaHostingVersion>1.5.31.1</AkkaHostingVersion>
+    <AkkaVersion>1.5.32</AkkaVersion>
+    <AkkaHostingVersion>1.5.32</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka.Persistence.Hosting" Version="$(AkkaHostingVersion) " />
     <PackageVersion Include="Akka.Persistence.Query" Version="$(AkkaVersion)" />
     <PackageVersion Include="Akka.Streams" Version="$(AkkaVersion) " />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="$(MongoDbVersion)" />
     <PackageVersion Include="MongoDB.Driver.GridFS" Version="$(MongoDbVersion)" />
   </ItemGroup>

--- a/src/examples/LargeSnapshot/LargeSnapshot.csproj
+++ b/src/examples/LargeSnapshot/LargeSnapshot.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Persistence.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

Test and sample projects now need to reference `Microsoft.Extensions.Hosting` directly because `Akka.Hosting` does not reference it anymore.