### PR TITLE
Update RELEASE_NOTES.md for 1.5.32-beta1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,12 +6,12 @@
 
 **Breaking Change Notice** 
 
-Due to breaking changes in MongoDb.Driver v3.0.0, This beta release will not support:
- * MongoDb server v3.6 and earlier
- * Projects that targets .NET Core 2.x and lower
- * Projects that targets .NET Framework 2.7.1 and lower
- * LINQ2 provider
- * TLS 1.0 and 1.1
+Due to breaking changes in MongoDb.Driver v3.0.0, from this point forward, Akka.Persistence.MongoDb releases **WILL NOT** support:
+* MongoDb server v3.6 and earlier
+* Projects that targets .NET Core 2.x and lower
+* Projects that targets .NET Framework 2.7.1 and lower
+* LINQ2 provider
+* TLS 1.0 and 1.1
 
 MongoDb.Driver 3.0.0 release note: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.0.0
  

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+#### 1.5.32-beta1 December 5th 2024 ####
+
+* [Bump Akka.NET to 1.5.32](https://github.com/akkadotnet/akka.net/releases/tag/1.5.32)
+* [Bump Akka.Persistence.Hosting to 1.5.32](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.32)
+* [Bump MongoDB.Driver to 3.0.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/395)
+
+**Breaking Change Notice** 
+
+Due to breaking changes in MongoDb.Driver v3.0.0, This beta release will not support:
+ * MongoDb server v3.6 and earlier
+ * Projects that targets .NET Core 2.x and lower
+ * Projects that targets .NET Framework 2.7.1 and lower
+ * LINQ2 provider
+ * TLS 1.0 and 1.1
+
+MongoDb.Driver 3.0.0 release note: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.0.0
+ 
+MongoDb.Driver 3.0.0 Upgrade advisory: https://www.mongodb.com/docs/drivers/csharp/v3.0/upgrade/v3/ 
+
 #### 1.5.31 December 4th 2024 ####
 
 * [Bump Akka.NET to 1.5.31](https://github.com/akkadotnet/akka.net/releases/tag/1.5.31)


### PR DESCRIPTION
## 1.5.32-beta1 December 5th 2024

* [Bump Akka.NET to 1.5.32](https://github.com/akkadotnet/akka.net/releases/tag/1.5.32)
* [Bump Akka.Persistence.Hosting to 1.5.32](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.32)
* [Bump MongoDB.Driver to 3.0.0](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/395)

### **Breaking Change Notice**

Due to breaking changes in MongoDb.Driver v3.0.0, from this point forward, Akka.Persistence.MongoDb releases **WILL NOT** support:
* MongoDb server v3.6 and earlier
* Projects that targets .NET Core 2.x and lower
* Projects that targets .NET Framework 2.7.1 and lower
* LINQ2 provider
* TLS 1.0 and 1.1

MongoDb.Driver 3.0.0 release note: https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.0.0
 
MongoDb.Driver 3.0.0 Upgrade advisory: https://www.mongodb.com/docs/drivers/csharp/v3.0/upgrade/v3/ 