### PR TITLE
Fix journal and snapshot write atomicity

### DIFF
--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -11,7 +11,6 @@ using Akka.Persistence.MongoDb.Query;
 using Akka.Util;
 using MongoDB.Bson;
 using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -151,6 +150,18 @@ namespace Akka.Persistence.MongoDb.Journal
             return unitedCts;
         }
 
+        private async Task<T> MaybeWriteWithTransaction<T>(Func<IClientSessionHandle?, CancellationToken, Task<T>> act, CancellationToken token)
+        {
+            if (!_settings.Transaction)
+            {
+                return await act(null, token);
+            }
+            
+            using var session = await GetMongoDb().Client.StartSessionAsync(EmptySessionOptions, token);
+            return await session.WithTransactionAsync(
+                async (s, ct) => await act(s, ct), cancellationToken:token);
+        }
+        
         private async Task MaybeWriteWithTransaction(Func<IClientSessionHandle?, CancellationToken, Task> act, CancellationToken token)
         {
             if (!_settings.Transaction)
@@ -164,7 +175,7 @@ namespace Akka.Persistence.MongoDb.Journal
                 async (s, ct) =>
                 {
                     await act(s, ct);
-                    return Task.FromResult(NotUsed.Instance);
+                    return NotUsed.Instance;
                 }, cancellationToken:token);
         }
         
@@ -181,7 +192,7 @@ namespace Akka.Persistence.MongoDb.Journal
                 async (s, ct) =>
                 {
                     await act(s, ct);
-                    return Task.FromResult(NotUsed.Instance);
+                    return NotUsed.Instance;
                 }, cancellationToken:token);
         }
         
@@ -312,43 +323,54 @@ namespace Akka.Persistence.MongoDb.Journal
         
         protected override async Task<IImmutableList<Exception?>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
         {
+            var writeMessages = messages.Select(message => ((IImmutableList<IPersistentRepresentation>)message.Payload)
+                .Select(ToJournalEntry).ToArray()
+            ).ToArray();
+            
+            // Nothing to write, return immediately
+            if(writeMessages.Length == 0)
+                return ImmutableList<Exception?>.Empty;
+
             using var unitedCts = CreatePerCallCts();
             var journalCollection = await GetJournalCollection(unitedCts.Token);
-            
-            var writeTasks = messages.Select(async message =>
+
+            if (writeMessages.Length == 1 && writeMessages[0].Length == 1)
             {
-                var persistentMessages = (IImmutableList<IPersistentRepresentation>)message.Payload;
-
-                var journalEntries = persistentMessages.Select(ToJournalEntry);
-                await InsertEntries(journalCollection, journalEntries, unitedCts.Token);
-            }).ToArray();
-
-            var result = await Task<IImmutableList<Exception?>>
-                .Factory
-                .ContinueWhenAll(
-                    tasks: writeTasks.ToArray(),
-                    continuationFunction: tasks => tasks.Select(t => t.IsFaulted ? TryUnwrapException(t.Exception) : null).ToImmutableList(), 
-                    cancellationToken: unitedCts.Token);
+                // Optimization, we don't need to use any transactions if there is only one message to be persisted. 
+                // https://www.mongodb.com/docs/manual/core/write-operations-atomicity/#atomicity-and-transactions
+                try
+                {
+                    await journalCollection.InsertOneAsync(writeMessages[0][0], new InsertOneOptions(), unitedCts.Token);
+                }
+                catch (Exception e)
+                {
+                    return ImmutableList.Create<Exception?>([e]);
+                }
+                return ImmutableList.Create<Exception?>([null]);
+            }
             
-            return result;
-        }
-
-        private async ValueTask InsertEntries(IMongoCollection<JournalEntry> collection, IEnumerable<JournalEntry> entries, CancellationToken token)
-        {
-            await MaybeWriteWithTransaction(async (session, ct) =>
+            return await MaybeWriteWithTransaction(async (session, ct) =>
             {
+                var insertOptions = new InsertManyOptions { IsOrdered = true };
+
                 //https://www.mongodb.com/community/forums/t/insertone-vs-insertmany-is-one-preferred-over-the-other/135982/2
                 //https://www.mongodb.com/docs/manual/core/transactions-production-consideration/#runtime-limit
                 //https://www.mongodb.com/docs/manual/core/transactions-production-consideration/#oplog-size-limit
                 //https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limits-and-thresholds
                 //16MB: if is bigger than this that means you do it one by one. LET'S TALK ABOUT THIS
-                if(session is not null)
-                    await collection
-                        .InsertManyAsync(session, entries, new InsertManyOptions { IsOrdered = true }, cancellationToken: ct);
-                else
-                    await collection
-                        .InsertManyAsync(entries, new InsertManyOptions { IsOrdered = true }, cancellationToken: ct);
-            }, token);
+                var writeTasks = writeMessages.Select(journalEntries => 
+                        session is not null 
+                            ? journalCollection.InsertManyAsync(session, journalEntries, insertOptions, ct) 
+                            : journalCollection.InsertManyAsync(journalEntries, insertOptions, ct))
+                    .ToArray();
+                
+                return await Task<IImmutableList<Exception?>>
+                    .Factory
+                    .ContinueWhenAll(
+                        tasks: writeTasks,
+                        continuationFunction: tasks => tasks.Select(t => t.IsFaulted ? TryUnwrapException(t.Exception) : null).ToImmutableList(), 
+                        cancellationToken: ct);
+            }, unitedCts.Token);
         }
 
         protected override async Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
@@ -394,7 +416,7 @@ namespace Akka.Persistence.MongoDb.Journal
             }
             else
             {
-                tags = Array.Empty<string>();
+                tags = [];
             }
 
             // per https://github.com/akkadotnet/Akka.Persistence.MongoDB/issues/107

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -370,31 +370,29 @@ namespace Akka.Persistence.MongoDb.Journal
                 //https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limits-and-thresholds
                 //16MB: if is bigger than this that means you do it one by one. LET'S TALK ABOUT THIS
                 var exceptions = new Exception?[writeMessages.Length];
-                for (var i = 0; i < exceptions.Length; i++)
+                var writeTasks = writeMessages.Select(journalEntries =>
+                    {
+                        if (session is not null)
+                        {
+                            return journalEntries.Length == 1 
+                                ? journalCollection.InsertOneAsync(session, journalEntries[0], insertOneOptions, ct)
+                                    .ContinueWith(t => t.Exception, ct)
+                                : journalCollection.InsertManyAsync(session, journalEntries, insertManyOptions, ct)
+                                    .ContinueWith(t => t.Exception, ct);
+                        }
+                        return journalEntries.Length == 1 
+                            ? journalCollection.InsertOneAsync(journalEntries[0], insertOneOptions, ct)
+                                .ContinueWith(t => t.Exception, ct)
+                            : journalCollection.InsertManyAsync(journalEntries, insertManyOptions, ct)
+                                .ContinueWith(t => t.Exception, ct);
+                    });
+                
+                var index = 0;
+                foreach (var task in writeTasks)
                 {
-                    try
-                    {
-                        var journalEntries = writeMessages[i];
-                        if (journalEntries.Length == 1)
-                        {
-                            if(session is not null)
-                                await journalCollection.InsertOneAsync(session, journalEntries[0], insertOneOptions, ct);
-                            else
-                                await journalCollection.InsertOneAsync(journalEntries[0], insertOneOptions, ct);
-                        }
-                        else
-                        {
-                            if (session is not null)
-                                await journalCollection.InsertManyAsync(session, journalEntries, insertManyOptions, ct);
-                            else
-                                await journalCollection.InsertManyAsync(journalEntries, insertManyOptions, ct);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        exceptions[i] = e;
-                    }
+                    exceptions[index++] = await task;
                 }
+                
                 return exceptions.ToImmutableArray();
             }, unitedCts.Token);
         }

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -361,25 +361,41 @@ namespace Akka.Persistence.MongoDb.Journal
             
             return await MaybeWriteWithTransaction(async (session, ct) =>
             {
-                var insertOptions = new InsertManyOptions { IsOrdered = true };
+                var insertManyOptions = new InsertManyOptions { IsOrdered = true };
+                var insertOneOptions = new InsertOneOptions();
 
                 //https://www.mongodb.com/community/forums/t/insertone-vs-insertmany-is-one-preferred-over-the-other/135982/2
                 //https://www.mongodb.com/docs/manual/core/transactions-production-consideration/#runtime-limit
                 //https://www.mongodb.com/docs/manual/core/transactions-production-consideration/#oplog-size-limit
                 //https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limits-and-thresholds
                 //16MB: if is bigger than this that means you do it one by one. LET'S TALK ABOUT THIS
-                var writeTasks = writeMessages.Select(journalEntries => 
-                        session is not null 
-                            ? journalCollection.InsertManyAsync(session, journalEntries, insertOptions, ct) 
-                            : journalCollection.InsertManyAsync(journalEntries, insertOptions, ct))
-                    .ToArray();
-                
-                return await Task<IImmutableList<Exception?>>
-                    .Factory
-                    .ContinueWhenAll(
-                        tasks: writeTasks,
-                        continuationFunction: tasks => tasks.Select(t => t.IsFaulted ? TryUnwrapException(t.Exception) : null).ToImmutableList(), 
-                        cancellationToken: ct);
+                var exceptions = new Exception?[writeMessages.Length];
+                for (var i = 0; i < exceptions.Length; i++)
+                {
+                    try
+                    {
+                        var journalEntries = writeMessages[i];
+                        if (journalEntries.Length == 1)
+                        {
+                            if(session is not null)
+                                await journalCollection.InsertOneAsync(session, journalEntries[0], insertOneOptions, ct);
+                            else
+                                await journalCollection.InsertOneAsync(journalEntries[0], insertOneOptions, ct);
+                        }
+                        else
+                        {
+                            if (session is not null)
+                                await journalCollection.InsertManyAsync(session, journalEntries, insertManyOptions, ct);
+                            else
+                                await journalCollection.InsertManyAsync(journalEntries, insertManyOptions, ct);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions[i] = e;
+                    }
+                }
+                return exceptions.ToImmutableArray();
             }, unitedCts.Token);
         }
 

--- a/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
+++ b/src/Akka.Persistence.MongoDb/Snapshot/MongoDbSnapshotStore.cs
@@ -158,26 +158,16 @@ namespace Akka.Persistence.MongoDb.Snapshot
             var snapshotCollection = await GetSnapshotCollection(unitedCts.Token);
             
             var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
-            await MaybeWriteWithTransaction(async (session, token) =>
-            {
-                if (session is not null)
-                {
-                    await snapshotCollection.ReplaceOneAsync(
-                        session: session,
-                        filter: CreateSnapshotIdFilter(snapshotEntry.Id),
-                        replacement: snapshotEntry,
-                        options: new ReplaceOptions { IsUpsert = true }, 
-                        cancellationToken: token);
-                }
-                else
-                {
-                    await snapshotCollection.ReplaceOneAsync(
-                        filter: CreateSnapshotIdFilter(snapshotEntry.Id),
-                        replacement: snapshotEntry,
-                        options: new ReplaceOptions { IsUpsert = true }, 
-                        cancellationToken: token);
-                }
-            }, unitedCts.Token);
+            
+            // According to
+            // https://www.mongodb.com/docs/manual/core/write-operations-atomicity/#atomicity-and-transactions
+            // A MongoDb write or update to a single document is guaranteed to be atomic, we don't need to
+            // enforce transactions for these.
+            await snapshotCollection.ReplaceOneAsync(
+                filter: CreateSnapshotIdFilter(snapshotEntry.Id),
+                replacement: snapshotEntry,
+                options: new ReplaceOptions { IsUpsert = true }, 
+                cancellationToken: unitedCts.Token);
         }
 
         protected override async Task DeleteAsync(SnapshotMetadata metadata)
@@ -185,22 +175,20 @@ namespace Akka.Persistence.MongoDb.Snapshot
             using var unitedCts = CreatePerCallCts();
             var snapshotCollection = await GetSnapshotCollection(unitedCts.Token);
 
-            await MaybeWriteWithTransaction(async (session, token) =>
-            {
-                var builder = Builders<SnapshotEntry>.Filter;
-                var filter = builder.Eq(x => x.PersistenceId, metadata.PersistenceId);
+            var builder = Builders<SnapshotEntry>.Filter;
+            var filter = builder.Eq(x => x.PersistenceId, metadata.PersistenceId);
 
-                if (metadata.SequenceNr is > 0 and < long.MaxValue)
-                    filter &= builder.Eq(x => x.SequenceNr, metadata.SequenceNr);
+            if (metadata.SequenceNr is > 0 and < long.MaxValue)
+                filter &= builder.Eq(x => x.SequenceNr, metadata.SequenceNr);
 
-                if (metadata.Timestamp != DateTime.MinValue && metadata.Timestamp != DateTime.MaxValue)
-                    filter &= builder.Eq(x => x.Timestamp, metadata.Timestamp.Ticks);
+            if (metadata.Timestamp != DateTime.MinValue && metadata.Timestamp != DateTime.MaxValue)
+                filter &= builder.Eq(x => x.Timestamp, metadata.Timestamp.Ticks);
 
-                if(session is not null)
-                    await snapshotCollection.FindOneAndDeleteAsync(session, filter, cancellationToken: token);
-                else
-                    await snapshotCollection.FindOneAndDeleteAsync(filter, cancellationToken: token);
-            }, unitedCts.Token);
+            // According to
+            // https://www.mongodb.com/docs/manual/core/write-operations-atomicity/#atomicity-and-transactions
+            // A MongoDb write or update to a single document is guaranteed to be atomic, we don't need to
+            // enforce transactions for these.
+            await snapshotCollection.FindOneAndDeleteAsync(filter, cancellationToken: unitedCts.Token);
         }
 
         protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)


### PR DESCRIPTION
Two issues are addressed:
1. Right now, all write operations were done under transactions, if write transaction feature flag is turned on. But according to the [MongoDb documentation](https://www.mongodb.com/docs/manual/core/write-operations-atomicity/#atomicity-and-transactions), single document write or updates are already atomic and does not need to be enclosed inside a transaction.
2. Right now, when we do a bulk atomic write `WriteMessagesAsync()`, we're atomically writing each collection payload under separate transactions, which is **wrong**, the correct way is to cover all of the writes under a single transaction so that they can be written atomically.

## Changes

* Add non-transactioned single document write optimization to snapshot store and journal
* Refactor `WriteMessagesAsync()` to use a single transaction for its entire bulk write operation.