### PR TITLE
Avoid re-registering FullTypeNameDiscriminatorConvention

### DIFF
--- a/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
+++ b/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -17,10 +18,12 @@ namespace Akka.Persistence.MongoDb
     /// <summary>
     /// Represents a serializer for objects.
     /// </summary>
-    internal class FullTypeNameObjectSerializer : ClassSerializerBase<object>, IHasDiscriminatorConvention
+    public class FullTypeNameObjectSerializer : ClassSerializerBase<object>, IHasDiscriminatorConvention
     {
+        private static readonly ConcurrentDictionary<Type, bool> s_registeredTypes = new();
+
         private readonly ObjectSerializer _serializer;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FullTypeNameObjectSerializer"/> class.
         /// </summary>
@@ -64,22 +67,26 @@ namespace Akka.Persistence.MongoDb
         /// If the type is not registered, attach it to our discriminator
         /// </summary>
         /// <param name="actualType">the type to examine</param>
-        private void RegisterNewTypesToDiscriminator(Type actualType)
+        public static void RegisterNewTypesToDiscriminator(Type actualType)
         {
-            // we've detected a new concrete type that isn't registered in MongoDB's serializer
-            if (actualType != typeof(object) && !actualType.GetTypeInfo().IsInterface && !BsonSerializer.IsTypeDiscriminated(actualType))
+            if (actualType == typeof(object) || actualType.GetTypeInfo().IsInterface || BsonSerializer.IsTypeDiscriminated(actualType)
+                || s_registeredTypes.ContainsKey(actualType))
             {
-                try
-                {
-                    BsonSerializer.RegisterDiscriminatorConvention(actualType, DiscriminatorConvention);
-                    BsonSerializer.RegisterDiscriminator(actualType, DiscriminatorConvention.GetDiscriminator(typeof(object), actualType));
-                }
-                catch (BsonSerializationException)
-                {
-                    // the MongoDB driver library has no nice mechanism for checking if a discriminator convention is registerd.
-                    // The "Lookup" logic tends to define a default if it doesn't exist.
-                    // So we're forced to eat the "duplicate registration" exception.
-                }
+                return;
+            }
+
+            try
+            {
+                // we've likely detected a new concrete type that isn't registered in MongoDB's serializer
+                BsonSerializer.RegisterDiscriminatorConvention(actualType, DiscriminatorConvention);
+                BsonSerializer.RegisterDiscriminator(actualType, DiscriminatorConvention.GetDiscriminator(typeof(object), actualType));
+                s_registeredTypes.TryAdd(actualType, true);
+            }
+            catch (BsonSerializationException)
+            {
+                // Ignore re-registration errors that may occur due to multiple concurrent registrations or
+                // if library user has registered their own IDiscriminatorConvention for actualType.
+                s_registeredTypes.TryAdd(actualType, true);
             }
         }
     }

--- a/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
+++ b/src/Akka.Persistence.MongoDb/FullTypeNameObjectSerializer.cs
@@ -78,8 +78,8 @@ namespace Akka.Persistence.MongoDb
             try
             {
                 // we've likely detected a new concrete type that isn't registered in MongoDB's serializer
-                BsonSerializer.RegisterDiscriminatorConvention(actualType, DiscriminatorConvention);
-                BsonSerializer.RegisterDiscriminator(actualType, DiscriminatorConvention.GetDiscriminator(typeof(object), actualType));
+                BsonSerializer.RegisterDiscriminatorConvention(actualType, FullTypeNameDiscriminatorConvention.Instance);
+                BsonSerializer.RegisterDiscriminator(actualType, FullTypeNameDiscriminatorConvention.Instance.GetDiscriminator(typeof(object), actualType));
                 s_registeredTypes.TryAdd(actualType, true);
             }
             catch (BsonSerializationException)


### PR DESCRIPTION
Avoid re-registering FullTypeNameDiscriminatorConvention and corresponding discriminator for BSON serialized types to avoid acquiring write lock.

Fixes #427

## Changes
Add a static `ConcurrentDictionary<Type, bool>` object to `FullTypeNameObjectSerializer` that keeps track of types that have already had discriminator and discriminator convention registered for them. Check against this object before attempting to register discriminator and discriminator convention to avoid re-registration and thus potential lock contention.

Also, make `FullTypeNameObjectSerializer` a public class and its `RegisterNewTypesToDiscriminator` method a static method. This allows library users to "pre-register" discriminator and discriminator conventions and not rely on these registrations being done lazily. This helps avoid lock contention issues if lots of persistent actors are started up after a restart of an Akka.NET app.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [v ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [v] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [v] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ v] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
