### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,39 +2,12 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2021 Akka.NET Project</Copyright>
     <Authors>Akka.NET Contrib</Authors>
-    <VersionPrefix>1.5.53</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageReleaseNotes>* [Bump Akka.NET to 1.5.53](https://github.com/akkadotnet/akka.net/releases/tag/1.5.53)
-* [Bump Akka.Persistence.Hosting to 1.5.53](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.53)
-* [Implement hosting healthcheck](https://github.com/akkadotnet/Akka.Persistence.MongoDB/pull/421)
-
-**New Feature: Health Check Support for Akka.Persistence.MongoDb.Hosting**
-
-This release adds built-in health check support for MongoDB journal and snapshot stores, integrated with [Microsoft.Extensions.Diagnostics.HealthChecks](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks). This enables monitoring and observability for your MongoDB persistence plugins.
-
-Key capabilities:
-* Automatic health reporting for MongoDB journal and snapshot stores
-* Integration with ASP.NET Core health check endpoints
-* Configurable health status reporting (Healthy, Degraded, Unhealthy)
-* Tagged health checks for easy filtering (`akka`, `persistence`, `mongodb`)
-
-Example usage:
-```csharp
-services.AddHealthChecks(); // Add health check service
-
-services.AddAkka("MyActorSystem", (builder, provider) =&gt;
-{
-    builder
-        .WithMongoDbPersistence(
-            connectionString: "mongodb://localhost:27017/akka",
-            journalBuilder: journal =&gt; journal.WithHealthCheck(HealthStatus.Degraded),
-            snapshotBuilder: snapshot =&gt; snapshot.WithHealthCheck(HealthStatus.Degraded));
-});
-```
-
-For complete documentation, see the [Akka.Persistence.MongoDb.Hosting README](src/Akka.Persistence.MongoDb.Hosting/README.md) and the main [README](README.md#health-check-support).</PackageReleaseNotes>
+    <PackageReleaseNotes>* [Bump Akka.NET to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* [Bump Akka.Hosting to 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Akka Persistence journal and snapshot store backed by MongoDB database.</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MongoDbVersion>3.0.0</MongoDbVersion>
-    <AkkaVersion>1.5.55</AkkaVersion>
-    <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
+    <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.59 January 24th 2026 ####
+
+* [Bump Akka.NET to 1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+* [Bump Akka.Hosting to 1.5.59](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)
+
 #### 1.5.55.1 October 29th 2025 ####
 
 **Improved API**


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59
- Upgrade Akka.Hosting to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
- [Akka.Hosting 1.5.59 Release Notes](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)