### PR TITLE
Fix: Use windows-2022 in release pipeline

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -20,7 +20,7 @@ variables:
 jobs:
   - job: Release
     pool:
-      vmImage: windows-latest
+      vmImage: windows-2022
       demands: Cmd
     steps:
       - task: UseDotNet@2


### PR DESCRIPTION
Azure DevOps windows-latest bug workaround.