### PR TITLE
spike: FromEnd (last-N) query offset — design validation (DO NOT MERGE)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2021 Akka.NET Project</Copyright>
     <Authors>Akka.NET Contrib</Authors>
-    <VersionPrefix>1.5.59</VersionPrefix>
+    <VersionPrefix>1.5.70-beta1</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Akka.Persistence.MongoDB/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MongoDbVersion>3.0.0</MongoDbVersion>
-    <AkkaVersion>1.5.68</AkkaVersion>
+    <AkkaVersion>1.5.70-beta1</AkkaVersion>
     <AkkaHostingVersion>1.5.69</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbFromEndOffsetSpec.cs
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------
+// <copyright file="MongoDbFromEndOffsetSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.MongoDB>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Akka.Persistence.TCK.Query;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    [Collection("MongoDbSpec")]
+    public class MongoDbTransactionFromEndOffsetSpec : MongoDbFromEndOffsetSpecBase
+    {
+        public MongoDbTransactionFromEndOffsetSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(output, databaseFixture, useTransaction: true) { }
+    }
+
+    [Collection("MongoDbSpec")]
+    public class MongoDbFromEndOffsetSpec : MongoDbFromEndOffsetSpecBase
+    {
+        public MongoDbFromEndOffsetSpec(ITestOutputHelper output, DatabaseFixture databaseFixture)
+            : base(output, databaseFixture, useTransaction: false) { }
+    }
+
+    public abstract class MongoDbFromEndOffsetSpecBase : FromEndOffsetSpec, IClassFixture<DatabaseFixture>
+    {
+        private static readonly AtomicCounter Counter = new AtomicCounter(0);
+
+        protected MongoDbFromEndOffsetSpecBase(ITestOutputHelper output, DatabaseFixture databaseFixture, bool useTransaction)
+            : base(CreateSpecConfig(databaseFixture, Counter.GetAndIncrement(), useTransaction), "MongoDbFromEndOffsetSpec", output)
+        {
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id, bool useTransaction)
+        {
+            var specString = $$"""
+akka.test.single-expect-default = 10s
+akka.persistence {
+    publish-plugin-commands = on
+    journal {
+        plugin = "akka.persistence.journal.mongodb"
+        mongodb {
+            class = "Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb"
+            connection-string = "{{databaseFixture.MongoDbConnectionString(id)}}"
+            use-write-transaction = {{(useTransaction ? "on" : "off")}}
+            auto-initialize = on
+            collection = "EventJournal"
+            event-adapters {
+                color-tagger = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK"
+            }
+            event-adapter-bindings {
+                "System.String" = color-tagger
+            }
+        }
+    }
+    snapshot-store {
+        plugin = "akka.persistence.snapshot-store.mongodb"
+        mongodb {
+            class = "Akka.Persistence.MongoDb.Snapshot.MongoDbSnapshotStore, Akka.Persistence.MongoDb"
+            connection-string = "{{databaseFixture.MongoDbConnectionString(id)}}"
+            use-write-transaction = {{(useTransaction ? "on" : "off")}}
+        }
+    }
+    query {
+        mongodb {
+            class = "Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb"
+            refresh-interval = 1s
+        }
+    }
+}
+""";
+            return ConfigurationFactory.ParseString(specString);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -587,6 +587,13 @@ namespace Akka.Persistence.MongoDb.Journal
                         .PipeTo(request.ReplyTo,
                             success: result => new CurrentPersistenceIds(result.Ids, request.Offset));
                     return true;
+                case FindFromEndOffset request:
+                    var sender = Sender;
+                    FindFromEndOffsetAsync(request.Tag, request.Count)
+                        .PipeTo(sender,
+                            success: offset => new FromEndOffsetResult(offset),
+                            failure: ex => new Status.Failure(ex));
+                    return true;
                 default:
                     return false;
             }
@@ -604,6 +611,15 @@ namespace Akka.Persistence.MongoDb.Journal
                 var lastOrdering = await journalCollection.HighestOrderingQuery(session, token);
                 return (ids, lastOrdering);
             }, unitedCts.Token);
+        }
+
+        private async Task<long> FindFromEndOffsetAsync(string? tag, int count)
+        {
+            using var unitedCts = CreatePerCallCts();
+            var journalCollection = await GetJournalCollection(unitedCts.Token);
+            return await MaybeReadWithTransaction(
+                async (session, token) => await journalCollection.FromEndOrderingQuery(session, tag, count, token),
+                unitedCts.Token);
         }
 
         protected virtual async Task<long> ReplayAllEventsAsync(ReplayAllEvents replay)

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournalQueries.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournalQueries.cs
@@ -180,6 +180,41 @@ internal static class MongoDbJournalQueries
     /// The session parameter signals if this query is being called as part of a transaction block or not
     /// NEVER CALL THIS METHOD OUTSIDE OF MaybeWithTransaction BLOCK
     /// </summary>
+    /// <summary>
+    /// Returns the exclusive-start ordering value that, when used as a <c>fromOffset</c>, makes the
+    /// next forward query return exactly the last <paramref name="count"/> matching events.
+    /// <para>
+    /// Strategy: sort descending, skip <paramref name="count"/> to land on the event just before the
+    /// desired window, and return its ordering value as the exclusive lower bound. When fewer than
+    /// <paramref name="count"/> events exist the method returns 0 (= start from the very beginning).
+    /// </para>
+    /// </summary>
+    public static async Task<long> FromEndOrderingQuery(
+        this IMongoCollection<JournalEntry> collection,
+        IClientSessionHandle? session,
+        string? tag,
+        int count,
+        CancellationToken token)
+    {
+        if (count <= 0) return 0L;
+
+        var builder = Builders<JournalEntry>.Filter;
+        var filter = string.IsNullOrWhiteSpace(tag)
+            ? FilterDefinition<JournalEntry>.Empty
+            : builder.AnyEq(x => x.Tags, tag);
+
+        // Skip `count` from the end → the anchor is the event immediately before our window.
+        // Its Ordering.Value is the exclusive lower bound: Gt(anchor) returns exactly the last N events.
+        var anchor = await (session is not null ? collection.Find(session, filter) : collection.Find(filter))
+            .SortByDescending(x => x.Ordering)
+            .Skip(count)
+            .Limit(1)
+            .Project(e => e.Ordering)
+            .FirstOrDefaultAsync(token);
+
+        return anchor?.Value ?? 0L;
+    }
+
     public static async Task<long> HighestOrderingQuery(this IMongoCollection<JournalEntry> collection, IClientSessionHandle? session, CancellationToken token)
     {
         var max = await (session is not null ? collection.AsQueryable(session) : collection.AsQueryable())

--- a/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
@@ -31,6 +31,9 @@ namespace Akka.Persistence.MongoDb.Query
 
         private readonly object _lock = new object();
         private IPublisher<string> _persistenceIdsPublisher;
+        private IActorRef? _journalRef;
+        private IActorRef JournalRef =>
+            _journalRef ??= Persistence.Instance.Apply(_system).JournalFor(_writeJournalPluginId);
 
         /// <inheritdoc />
         public MongoDbReadJournal(ExtendedActorSystem system, Config config)
@@ -193,10 +196,26 @@ namespace Akka.Persistence.MongoDb.Query
         /// The stream is completed with failure if there is a failure in executing the query in the
         /// backend journal.
         /// </summary>
+        // Resolves a FromEnd(N) offset into a concrete exclusive-start ordering value, then defers
+        // to the normal forward-streaming query via ConcatMany.
+        private Source<EventEnvelope, NotUsed> ResolveFromEnd(
+            string? tag, int count, Func<long, Source<EventEnvelope, NotUsed>> continuation)
+            => Source.FromTask(
+                    JournalRef.Ask<FromEndOffsetResult>(
+                        new FindFromEndOffset(tag, count),
+                        TimeSpan.FromSeconds(30)))
+                .Select(r => r.Offset)
+                .ConcatMany(continuation);
+
         public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset = null)
         {
             offset = offset ?? new Sequence(0L);
             switch (offset) {
+                case FromEnd fe:
+                    return ResolveFromEnd(tag, fe.Count, start =>
+                        Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, start, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named($"EventsByTag-{tag}"));
                 case Sequence seq:
                     return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                         .MapMaterializedValue(_ => NotUsed.Instance)
@@ -204,7 +223,7 @@ namespace Akka.Persistence.MongoDb.Query
                 case NoOffset _:
                     return EventsByTag(tag, new Sequence(0L));
                 default:
-                    throw new ArgumentException($"SqlReadJournal does not support {offset.GetType().Name} offsets");
+                    throw new ArgumentException($"MongoDbReadJournal does not support {offset.GetType().Name} offsets");
             }
         }
 
@@ -217,6 +236,11 @@ namespace Akka.Persistence.MongoDb.Query
         {
             offset = offset ?? new Sequence(0L);
             switch (offset) {
+                case FromEnd fe:
+                    return ResolveFromEnd(tag, fe.Count, start =>
+                        Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, start, long.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named($"CurrentEventsByTag-{tag}"));
                 case Sequence seq:
                     return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
                         .MapMaterializedValue(_ => NotUsed.Instance)
@@ -224,7 +248,7 @@ namespace Akka.Persistence.MongoDb.Query
                 case NoOffset _:
                     return CurrentEventsByTag(tag, new Sequence(0L));
                 default:
-                    throw new ArgumentException($"SqlReadJournal does not support {offset.GetType().Name} offsets");
+                    throw new ArgumentException($"MongoDbReadJournal does not support {offset.GetType().Name} offsets");
             }
         }
 
@@ -260,23 +284,25 @@ namespace Akka.Persistence.MongoDb.Query
         /// </summary>
         public Source<EventEnvelope, NotUsed> AllEvents(Offset offset = null)
         {
-            Sequence seq;
             switch (offset)
             {
+                case FromEnd fe:
+                    return ResolveFromEnd(null, fe.Count, start =>
+                        Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(start, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named("AllEvents"));
                 case null:
                 case NoOffset _:
-                    seq = new Sequence(0L);
-                    break;
+                    return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(0L, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                        .MapMaterializedValue(_ => NotUsed.Instance)
+                        .Named("AllEvents");
                 case Sequence s:
-                    seq = s;
-                    break;
+                    return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(s.Value, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+                        .MapMaterializedValue(_ => NotUsed.Instance)
+                        .Named("AllEvents");
                 default:
                     throw new ArgumentException($"MongoDbReadJournal does not support {offset.GetType().Name} offsets");
             }
-
-            return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(seq.Value, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
-                .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("AllEvents");
         }
 
         /// <summary>
@@ -286,23 +312,25 @@ namespace Akka.Persistence.MongoDb.Query
         /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
         {
-            Sequence seq;
             switch (offset)
             {
+                case FromEnd fe:
+                    return ResolveFromEnd(null, fe.Count, start =>
+                        Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(start, null, _maxBufferSize, _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named("CurrentAllEvents"));
                 case null:
                 case NoOffset _:
-                    seq = new Sequence(0L);
-                    break;
+                    return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(0L, null, _maxBufferSize, _writeJournalPluginId))
+                        .MapMaterializedValue(_ => NotUsed.Instance)
+                        .Named("CurrentAllEvents");
                 case Sequence s:
-                    seq = s;
-                    break;
+                    return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(s.Value, null, _maxBufferSize, _writeJournalPluginId))
+                        .MapMaterializedValue(_ => NotUsed.Instance)
+                        .Named("CurrentAllEvents");
                 default:
                     throw new ArgumentException($"MongoDbReadJournal does not support {offset.GetType().Name} offsets");
             }
-
-            return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(seq.Value, null, _maxBufferSize, _writeJournalPluginId))
-                .MapMaterializedValue(_ => NotUsed.Instance)
-                .Named("CurrentAllEvents");
         }
        
     }

--- a/src/Akka.Persistence.MongoDb/Query/QueryApi.cs
+++ b/src/Akka.Persistence.MongoDb/Query/QueryApi.cs
@@ -175,6 +175,43 @@ namespace Akka.Persistence.MongoDb.Query
     /// <summary>
     /// TBD
     /// </summary>
+    /// <summary>
+    /// Ask the journal for the exclusive-start ordering value that makes the next query
+    /// return the last <see cref="Count"/> matching events. Used to resolve
+    /// <see cref="Akka.Persistence.Query.FromEnd"/> offsets without exposing MongoDB
+    /// internals to the read journal.
+    /// </summary>
+    [Serializable]
+    public sealed class FindFromEndOffset : IJournalRequest
+    {
+        /// <summary>Optional tag filter; null means all-events.</summary>
+        public string? Tag { get; }
+
+        /// <summary>Number of events from the end to include in the window.</summary>
+        public int Count { get; }
+
+        public FindFromEndOffset(string? tag, int count)
+        {
+            Tag = tag;
+            Count = count;
+        }
+    }
+
+    /// <summary>
+    /// Response to <see cref="FindFromEndOffset"/> — the exclusive-start ordering value
+    /// (a <c>BsonTimestamp.Value</c>) to pass as <c>fromOffset</c> to the appropriate publisher.
+    /// </summary>
+    [Serializable]
+    public sealed class FromEndOffsetResult
+    {
+        public long Offset { get; }
+
+        public FromEndOffsetResult(long offset)
+        {
+            Offset = offset;
+        }
+    }
+
     [Serializable]
     public sealed class ReplayAllEvents : IJournalRequest
     {


### PR DESCRIPTION
## Summary

Proof-of-concept implementation of `Offset.FromEnd(N)` for the MongoDB read journal, parallel to the SQL spike in akkadotnet/Akka.Persistence.Sql#589.

- `MongoDbJournalQueries.FromEndOrderingQuery` — sort descending, skip N, take 1 to find the exclusive-start anchor ordering value (the event immediately before the last-N window)
- `MongoDbJournal` — handles new `FindFromEndOffset` ask message and delegates to the queries layer
- `MongoDbReadJournal` — adds `ResolveFromEnd` helper (Ask → ConcatMany) and a `FromEnd` case to all 4 query methods (`AllEvents`, `CurrentAllEvents`, `EventsByTag`, `CurrentEventsByTag`)
- `MongoDbFromEndOffsetSpec` — wires the new `Akka.Persistence.TCK.FromEndOffsetSpec` against an in-process MongoDB instance (Mongo2Go) with `ColorFruitTagger`
- Bumps to Akka.NET `1.5.70-beta1` which carries the `FromEnd` type in `Akka.Persistence.Query`; `AkkaHostingVersion` stays at `1.5.67` (no Hosting beta1 published yet)

Relates to akkadotnet/akka.net#8244

**DO NOT MERGE** — spike/design validation only