### PR TITLE
Clean up FluentAssertions remnants

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,6 @@
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="FluentAssertions" Version="5.10.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Bug61FixSpec.cs
@@ -105,8 +105,6 @@ namespace Akka.Persistence.MongoDb.Tests
             var eventsByTag = ReadJournal.EventsByTag(typeof(RealMsg).Name)
                 .RunForeach(e => TestActor.Tell(e), Materializer);
 
-            // can't do this because Offset isn't IComparable
-            // ReceiveN(msgCount).Cast<EventEnvelope>().Select(x => x.Offset).Should().BeInAscendingOrder();
             ReceiveN(msgCount);
 
             // should receive more messages after the fact

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/HealthCheckSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/HealthCheckSpec.cs
@@ -77,20 +77,20 @@ public class HealthCheckSpec : Akka.Hosting.TestKit.TestKit, IClassFixture<Datab
             .Where(e => e.Key.Contains("Akka.Persistence", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        Assert.Equal(2, (persistenceHealthChecks)?.Count());
+        Assert.Equal(2, persistenceHealthChecks.Count);
 
         // Verify journal health check exists and is healthy
-        var journalHealthCheck = persistenceHealthChecks
-            .FirstOrDefault(e => e.Key.Contains("journal", StringComparison.OrdinalIgnoreCase));
+        var journalHealthCheck = Assert.Single(
+            persistenceHealthChecks,
+            e => e.Key.Contains("journal", StringComparison.OrdinalIgnoreCase));
 
-        Assert.NotNull(journalHealthCheck);
         Assert.Equal(HealthStatus.Healthy, journalHealthCheck.Value.Status);
 
         // Verify snapshot health check exists and is healthy
-        var snapshotHealthCheck = persistenceHealthChecks
-            .FirstOrDefault(e => e.Key.Contains("snapshot", StringComparison.OrdinalIgnoreCase));
+        var snapshotHealthCheck = Assert.Single(
+            persistenceHealthChecks,
+            e => e.Key.Contains("snapshot", StringComparison.OrdinalIgnoreCase));
 
-        Assert.NotNull(snapshotHealthCheck);
         Assert.Equal(HealthStatus.Healthy, snapshotHealthCheck.Value.Status);
 
         // Verify overall health status


### PR DESCRIPTION
## Changes
- remove the unused central FluentAssertions package version
- remove the stale commented FluentAssertions assertion
- replace ineffective null checks on KeyValuePair values with predicate-based Assert.Single checks

## Validation
- dotnet test src/Akka.Persistence.MongoDb.Tests/Akka.Persistence.MongoDb.Tests.csproj --configuration Release --filter "FullyQualifiedName~MongoDbJournalOptionsSpec|FullyQualifiedName~MongoDbSnapshotOptionsSpec|FullyQualifiedName~MongoDbSettingsSpec"
- 12 tests passed
- no FluentAssertions or .Should() references remain