### PR TITLE
Preserve all event tags in EventsByTag envelopes

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByTagSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByTagSpec.cs
@@ -12,7 +12,9 @@ using Akka.Persistence.MongoDb.Query;
 using Akka.Persistence.Query;
 using Akka.Util.Internal;
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Streams.TestKit;
 
 namespace Akka.Persistence.MongoDb.Tests
 {
@@ -50,6 +52,26 @@ namespace Akka.Persistence.MongoDb.Tests
         }
 
         protected override bool SupportsTagsInEventEnvelope => true;
+
+        [Fact]
+        public async Task ReadJournal_query_EventsByTag_should_include_all_event_tags_in_EventEnvelope()
+        {
+            var queries = (IEventsByTagQuery)ReadJournal;
+            var actor = Sys.ActorOf(TestActor.Props("multi-tag"));
+
+            actor.Tell("a green apple");
+            await ExpectMsgAsync("a green apple-done", cancellationToken: TestContext.Current.CancellationToken);
+
+            var probe = queries.EventsByTag("green", Offset.NoOffset())
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            await probe.RequestAsync(1);
+
+            var envelope = await probe.ExpectNextAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(2, envelope.Tags.Length);
+            Assert.Contains("green", envelope.Tags);
+            Assert.Contains("apple", envelope.Tags);
+            await probe.CancelAsync();
+        }
 
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id, bool transaction)
         {

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -284,7 +284,7 @@ namespace Akka.Persistence.MongoDb.Journal
                     {
                         var persistent = ToPersistenceRepresentation(entry, ActorRefs.NoSender);
                         foreach (var adapted in AdaptFromJournal(persistent))
-                            replay.ReplyTo.Tell(new ReplayedTaggedMessage(adapted, tag, entry.Ordering.Value),
+                            replay.ReplyTo.Tell(new ReplayedEvent(adapted, entry.Ordering.Value, entry.Tags.ToArray()),
                                 ActorRefs.NoSender);
                     }, ct);
                 

--- a/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
+++ b/src/Akka.Persistence.MongoDb/Query/EventsByTagPublisher.cs
@@ -119,14 +119,14 @@ namespace Akka.Persistence.MongoDb.Query
             {
                 switch (message)
                 {
-                    case ReplayedTaggedMessage replayed:
+                    case ReplayedEvent replayed:
                         Buffer.Add(new EventEnvelope(
                             offset: new Sequence(replayed.Offset),
                             persistenceId: replayed.Persistent.PersistenceId,
                             sequenceNr: replayed.Persistent.SequenceNr,
                             timestamp: replayed.Persistent.Timestamp,
                             @event: replayed.Persistent.Payload,
-                            tags: new [] { replayed.Tag }));
+                            tags: replayed.Tags));
 
                         CurrentOffset = replayed.Offset;
                         Buffer.DeliverBuffer(TotalDemand);


### PR DESCRIPTION
## Summary

`EventsByTag` and `CurrentEventsByTag` currently populate `EventEnvelope.Tags` with only the tag used to execute the query. This loses any other tags stored with the event and makes the returned metadata depend on which tag was queried.

This change:

- reuses the existing `ReplayedEvent` message to carry the complete `JournalEntry.Tags` collection through tagged replay;
- constructs the `EventEnvelope` with that complete collection;
- makes no public API changes; and
- adds an async regression test using the existing multi-tag `"a green apple"` event in both transaction modes.

Related TCK coverage issue: akkadotnet/akka.net#8438.

## Validation

- `dotnet build Akka.Persistence.MongoDb.sln --no-restore` succeeds (existing warnings only).
- The focused regression test compiles without new analyzer warnings.
- The focused runtime test could not execute locally because Mongo2Go 4.0.0's bundled MongoDB 4.4 binary requires `libcrypto.so.1.1`, which is unavailable on this host. The failure occurs in `DatabaseFixture` before the test body runs; CI should exercise both transaction variants.
