### PR TITLE
Add Offset.FromEnd support to MongoDB queries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <MongoDbVersion>3.0.0</MongoDbVersion>
-    <AkkaVersion>1.5.69</AkkaVersion>
-    <AkkaHostingVersion>1.5.69</AkkaHostingVersion>
+    <AkkaVersion>1.5.70</AkkaVersion>
+    <AkkaHostingVersion>1.5.70</AkkaHostingVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.70 July 29th 2026 ####
+
+* [Bump Akka.NET to 1.5.70](https://github.com/akkadotnet/akka.net/releases/tag/1.5.70)
+* [Bump Akka.Hosting to 1.5.70](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.70)
+* Add support for `Offset.FromEnd` to current and live `EventsByTag` and `AllEvents` queries
+
 #### 1.5.67 April 28th 2026 ####
 
 * [Bump Akka.NET to 1.5.67](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67)

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbFromEndOffsetSpec.cs
@@ -1,0 +1,180 @@
+//-----------------------------------------------------------------------
+// <copyright file="MongoDbFromEndOffsetSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2017 Akka.NET Contrib <https://github.com/AkkaNetContrib/Akka.Persistence.MongoDB>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.MongoDb.Query;
+using Akka.Persistence.Query;
+using Akka.Persistence.TCK.Query;
+using Akka.Streams.Dsl;
+using Akka.Util.Internal;
+using Xunit;
+
+namespace Akka.Persistence.MongoDb.Tests
+{
+    public class MongoDbReadJournalConfigurationSpec
+    {
+        [Theory]
+        [InlineData("", 50)]
+        [InlineData("akka.persistence.journal.explicit", 65)]
+        public void FromEnd_Ask_timeout_should_follow_selected_journal_call_timeout(
+            string writePlugin,
+            int expectedAskTimeoutSeconds)
+        {
+            var config = ConfigurationFactory.ParseString("""
+akka.persistence.journal {
+    plugin = "akka.persistence.journal.default"
+    default.call-timeout = 45s
+    explicit.call-timeout = 60s
+}
+""");
+
+            var timeout = MongoDbReadJournal.ResolveFromEndAskTimeout(config, writePlugin);
+
+            Assert.Equal(TimeSpan.FromSeconds(expectedAskTimeoutSeconds), timeout);
+        }
+    }
+
+    [Collection("MongoDbSpec")]
+    public class MongoDbTransactionFromEndOffsetSpec : MongoDbFromEndOffsetSpecBase
+    {
+        public MongoDbTransactionFromEndOffsetSpec(
+            ITestOutputHelper output,
+            DatabaseFixture databaseFixture)
+            : base(output, databaseFixture, useTransaction: true)
+        {
+        }
+    }
+
+    [Collection("MongoDbSpec")]
+    public class MongoDbFromEndOffsetSpec : MongoDbFromEndOffsetSpecBase
+    {
+        public MongoDbFromEndOffsetSpec(
+            ITestOutputHelper output,
+            DatabaseFixture databaseFixture)
+            : base(output, databaseFixture, useTransaction: false)
+        {
+        }
+    }
+
+    public abstract class MongoDbFromEndOffsetSpecBase : FromEndOffsetSpec, IClassFixture<DatabaseFixture>
+    {
+        private static readonly AtomicCounter Counter = new AtomicCounter(0);
+
+        protected MongoDbFromEndOffsetSpecBase(
+            ITestOutputHelper output,
+            DatabaseFixture databaseFixture,
+            bool useTransaction)
+            : base(
+                CreateSpecConfig(databaseFixture, Counter.GetAndIncrement(), useTransaction),
+                "MongoDbFromEndOffsetSpec",
+                output)
+        {
+            ReadJournal = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
+        }
+
+        [Fact]
+        public async Task ReadJournal_FromEnd_should_resolve_again_for_each_materialization()
+        {
+            var queries = Assert.IsAssignableFrom<ICurrentAllEventsQuery>(ReadJournal);
+            var source = queries.CurrentAllEvents(new FromEnd(2));
+            var actor = Sys.ActorOf(JournalTestActor.Props("sequence-offsets"));
+
+            for (var i = 1; i <= 3; i++)
+            {
+                actor.Tell($"event-{i}");
+                await ExpectMsgAsync(
+                    $"event-{i}-done",
+                    cancellationToken: TestContext.Current.CancellationToken);
+            }
+
+            var firstMaterialization = await source
+                .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+            Assert.Collection(
+                firstMaterialization,
+                envelope =>
+                {
+                    Assert.Equal("event-2", envelope.Event);
+                    Assert.IsType<Sequence>(envelope.Offset);
+                },
+                envelope =>
+                {
+                    Assert.Equal("event-3", envelope.Event);
+                    Assert.IsType<Sequence>(envelope.Offset);
+                });
+
+            actor.Tell("event-4");
+            await ExpectMsgAsync(
+                "event-4-done",
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            var secondMaterialization = await source
+                .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+            Assert.Collection(
+                secondMaterialization,
+                envelope =>
+                {
+                    Assert.Equal("event-3", envelope.Event);
+                    Assert.IsType<Sequence>(envelope.Offset);
+                },
+                envelope =>
+                {
+                    Assert.Equal("event-4", envelope.Event);
+                    Assert.IsType<Sequence>(envelope.Offset);
+                });
+        }
+
+        private static Config CreateSpecConfig(
+            DatabaseFixture databaseFixture,
+            int id,
+            bool useTransaction)
+        {
+            var specString = $$"""
+akka.test.single-expect-default = 10s
+akka.persistence {
+    publish-plugin-commands = on
+    journal {
+        plugin = "akka.persistence.journal.mongodb"
+        mongodb {
+            class = "Akka.Persistence.MongoDb.Journal.MongoDbJournal, Akka.Persistence.MongoDb"
+            connection-string = "{{databaseFixture.MongoDbConnectionString(id)}}"
+            use-write-transaction = {{(useTransaction ? "on" : "off")}}
+            use-read-transaction = {{(useTransaction ? "on" : "off")}}
+            auto-initialize = on
+            collection = "EventJournal"
+            event-adapters {
+                color-tagger = "Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK"
+            }
+            event-adapter-bindings {
+                "System.String" = color-tagger
+            }
+        }
+    }
+    snapshot-store {
+        plugin = "akka.persistence.snapshot-store.mongodb"
+        mongodb {
+            class = "Akka.Persistence.MongoDb.Snapshot.MongoDbSnapshotStore, Akka.Persistence.MongoDb"
+            connection-string = "{{databaseFixture.MongoDbConnectionString(id)}}"
+            use-write-transaction = {{(useTransaction ? "on" : "off")}}
+            use-read-transaction = {{(useTransaction ? "on" : "off")}}
+        }
+    }
+    query {
+        mongodb {
+            class = "Akka.Persistence.MongoDb.Query.MongoDbReadJournalProvider, Akka.Persistence.MongoDb"
+            refresh-interval = 1s
+        }
+    }
+}
+""";
+            return ConfigurationFactory.ParseString(specString);
+        }
+    }
+}

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbFromEndOffsetSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbFromEndOffsetSpec.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -37,6 +38,21 @@ akka.persistence.journal {
             var timeout = MongoDbReadJournal.ResolveFromEndAskTimeout(config, writePlugin);
 
             Assert.Equal(TimeSpan.FromSeconds(expectedAskTimeoutSeconds), timeout);
+        }
+
+        [Fact]
+        public void FromEnd_Ask_timeout_should_preserve_infinite_journal_call_timeout()
+        {
+            var config = ConfigurationFactory.ParseString("""
+akka.persistence.journal {
+    plugin = "akka.persistence.journal.default"
+    default.call-timeout = infinite
+}
+""");
+
+            var timeout = MongoDbReadJournal.ResolveFromEndAskTimeout(config, "");
+
+            Assert.Equal(Timeout.InfiniteTimeSpan, timeout);
         }
     }
 
@@ -113,6 +129,18 @@ akka.persistence.journal {
             await ExpectMsgAsync(
                 "event-4-done",
                 cancellationToken: TestContext.Current.CancellationToken);
+
+            var resumeOffset = Assert.IsType<Sequence>(firstMaterialization[^1].Offset);
+            var resumed = await queries.CurrentAllEvents(resumeOffset)
+                .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+            Assert.Collection(
+                resumed,
+                envelope =>
+                {
+                    Assert.Equal("event-4", envelope.Event);
+                    Assert.IsType<Sequence>(envelope.Offset);
+                });
 
             var secondMaterialization = await source
                 .RunWith(Sink.Seq<EventEnvelope>(), Materializer);

--- a/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
+++ b/src/Akka.Persistence.MongoDb/Akka.Persistence.MongoDb.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="Akka.Streams" />
     <PackageReference Include="MongoDB.Driver" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Akka.Persistence.MongoDb.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -587,6 +587,13 @@ namespace Akka.Persistence.MongoDb.Journal
                         .PipeTo(request.ReplyTo,
                             success: result => new CurrentPersistenceIds(result.Ids, request.Offset));
                     return true;
+                case FindFromEndOffset request:
+                    FindFromEndOffsetAsync(request.Tag, request.Count)
+                        .PipeTo(
+                            Sender,
+                            success: offset => new FromEndOffsetResult(offset),
+                            failure: exception => new Status.Failure(exception));
+                    return true;
                 default:
                     return false;
             }
@@ -604,6 +611,16 @@ namespace Akka.Persistence.MongoDb.Journal
                 var lastOrdering = await journalCollection.HighestOrderingQuery(session, token);
                 return (ids, lastOrdering);
             }, unitedCts.Token);
+        }
+
+        private async Task<long> FindFromEndOffsetAsync(string? tag, int count)
+        {
+            using var unitedCts = CreatePerCallCts();
+            var journalCollection = await GetJournalCollection(unitedCts.Token);
+
+            return await MaybeReadWithTransaction(
+                (session, token) => journalCollection.FromEndOrderingQuery(session, tag, count, token),
+                unitedCts.Token);
         }
 
         protected virtual async Task<long> ReplayAllEventsAsync(ReplayAllEvents replay)

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournalQueries.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournalQueries.cs
@@ -176,6 +176,36 @@ internal static class MongoDbJournalQueries
     }
 
     /// <summary>
+    /// Returns the exclusive ordering offset immediately before the last <paramref name="count"/>
+    /// events matching <paramref name="tag"/>. A missing tag selects all events.
+    /// </summary>
+    internal static async Task<long> FromEndOrderingQuery(
+        this IMongoCollection<JournalEntry> collection,
+        IClientSessionHandle? session,
+        string? tag,
+        int count,
+        CancellationToken token)
+    {
+        if (count <= 0)
+            return 0L;
+
+        var filter = FilterDefinition<JournalEntry>.Empty;
+        if (!string.IsNullOrWhiteSpace(tag))
+            filter &= Builders<JournalEntry>.Filter.AnyEq(x => x.Tags, tag);
+
+        // Forward queries use an exclusive lower bound, so the anchor is the event
+        // immediately preceding the requested window.
+        var anchor = await (session is not null ? collection.Find(session, filter) : collection.Find(filter))
+            .SortByDescending(x => x.Ordering)
+            .Skip(count)
+            .Limit(1)
+            .Project(x => x.Ordering)
+            .FirstOrDefaultAsync(token);
+
+        return anchor?.Value ?? 0L;
+    }
+
+    /// <summary>
     /// NOTE: This query is meant to be a part of a persistence operation
     /// The session parameter signals if this query is being called as part of a transaction block or not
     /// NEVER CALL THIS METHOD OUTSIDE OF MaybeWithTransaction BLOCK

--- a/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
@@ -28,9 +28,14 @@ namespace Akka.Persistence.MongoDb.Query
         private readonly string _writeJournalPluginId;
         private readonly int _maxBufferSize;
         private readonly ExtendedActorSystem _system;
+        private readonly TimeSpan _fromEndAskTimeout;
 
         private readonly object _lock = new object();
         private IPublisher<string> _persistenceIdsPublisher;
+        private readonly Lazy<IActorRef> _journalRef;
+
+        private static readonly TimeSpan DefaultCallTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan FromEndAskTimeoutSlack = TimeSpan.FromSeconds(5);
 
         /// <inheritdoc />
         public MongoDbReadJournal(ExtendedActorSystem system, Config config)
@@ -39,8 +44,29 @@ namespace Akka.Persistence.MongoDb.Query
             _writeJournalPluginId = config.GetString("write-plugin");
             _maxBufferSize = config.GetInt("max-buffer-size"); 
             _system = system;
+            _fromEndAskTimeout = ResolveFromEndAskTimeout(
+                system.Settings.Config,
+                _writeJournalPluginId);
 
             _persistenceIdsPublisher = null;
+            _journalRef = new Lazy<IActorRef>(
+                () => Persistence.Instance.Apply(_system).JournalFor(_writeJournalPluginId));
+        }
+
+        internal static TimeSpan ResolveFromEndAskTimeout(
+            Config rootConfig,
+            string writeJournalPluginId)
+        {
+            var resolvedPluginId = string.IsNullOrEmpty(writeJournalPluginId)
+                ? rootConfig.GetString("akka.persistence.journal.plugin")
+                : writeJournalPluginId;
+            var journalConfig = rootConfig.GetConfig(resolvedPluginId);
+            var callTimeout = journalConfig?.GetTimeSpan("call-timeout", DefaultCallTimeout)
+                              ?? DefaultCallTimeout;
+
+            // The journal cancels the MongoDB operation at call-timeout. Keep the Ask alive
+            // long enough for that cancellation (or its result) to be piped back to the caller.
+            return callTimeout + FromEndAskTimeoutSlack;
         }
 
         /// <summary>
@@ -154,6 +180,25 @@ namespace Akka.Persistence.MongoDb.Query
                     .MapMaterializedValue(_ => NotUsed.Instance)
                     .Named("CurrentEventsByPersistenceId-" + persistenceId) as Source<EventEnvelope, NotUsed>;
 
+#nullable enable
+        private Source<EventEnvelope, NotUsed> ResolveFromEnd(
+            string? tag,
+            int count,
+            Func<Sequence, Source<EventEnvelope, NotUsed>> continuation)
+        {
+            // Source.Setup ensures the relative offset is resolved independently for each
+            // materialization, immediately before the normal forward query starts.
+            return Source.Setup<EventEnvelope, NotUsed>((_, _) =>
+                    Source.FromTask(
+                            _journalRef.Value.Ask<FromEndOffsetResult>(
+                                new FindFromEndOffset(tag, count),
+                                _fromEndAskTimeout))
+                        .Select(result => new Sequence(result.Offset))
+                        .ConcatMany(continuation))
+                .MapMaterializedValue(_ => NotUsed.Instance);
+        }
+#nullable restore
+
         /// <summary>
         /// <see cref="EventsByTag"/> is used for retrieving events that were marked with
         /// a given tag, e.g. all events of an Aggregate Root type.
@@ -197,6 +242,20 @@ namespace Akka.Persistence.MongoDb.Query
         {
             offset = offset ?? new Sequence(0L);
             switch (offset) {
+                case FromEnd fromEnd:
+                    return ResolveFromEnd(
+                        tag,
+                        fromEnd.Count,
+                        sequence => Source.ActorPublisher<EventEnvelope>(
+                                EventsByTagPublisher.Props(
+                                    tag,
+                                    sequence.Value,
+                                    long.MaxValue,
+                                    _refreshInterval,
+                                    _maxBufferSize,
+                                    _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named($"EventsByTag-{tag}"));
                 case Sequence seq:
                     return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                         .MapMaterializedValue(_ => NotUsed.Instance)
@@ -204,7 +263,7 @@ namespace Akka.Persistence.MongoDb.Query
                 case NoOffset _:
                     return EventsByTag(tag, new Sequence(0L));
                 default:
-                    throw new ArgumentException($"SqlReadJournal does not support {offset.GetType().Name} offsets");
+                    throw new ArgumentException($"MongoDbReadJournal does not support {offset.GetType().Name} offsets");
             }
         }
 
@@ -217,6 +276,20 @@ namespace Akka.Persistence.MongoDb.Query
         {
             offset = offset ?? new Sequence(0L);
             switch (offset) {
+                case FromEnd fromEnd:
+                    return ResolveFromEnd(
+                        tag,
+                        fromEnd.Count,
+                        sequence => Source.ActorPublisher<EventEnvelope>(
+                                EventsByTagPublisher.Props(
+                                    tag,
+                                    sequence.Value,
+                                    long.MaxValue,
+                                    null,
+                                    _maxBufferSize,
+                                    _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named($"CurrentEventsByTag-{tag}"));
                 case Sequence seq:
                     return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, seq.Value, long.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
                         .MapMaterializedValue(_ => NotUsed.Instance)
@@ -224,7 +297,7 @@ namespace Akka.Persistence.MongoDb.Query
                 case NoOffset _:
                     return CurrentEventsByTag(tag, new Sequence(0L));
                 default:
-                    throw new ArgumentException($"SqlReadJournal does not support {offset.GetType().Name} offsets");
+                    throw new ArgumentException($"MongoDbReadJournal does not support {offset.GetType().Name} offsets");
             }
         }
 
@@ -263,6 +336,18 @@ namespace Akka.Persistence.MongoDb.Query
             Sequence seq;
             switch (offset)
             {
+                case FromEnd fromEnd:
+                    return ResolveFromEnd(
+                        null,
+                        fromEnd.Count,
+                        sequence => Source.ActorPublisher<EventEnvelope>(
+                                AllEventsPublisher.Props(
+                                    sequence.Value,
+                                    _refreshInterval,
+                                    _maxBufferSize,
+                                    _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named("AllEvents"));
                 case null:
                 case NoOffset _:
                     seq = new Sequence(0L);
@@ -289,6 +374,18 @@ namespace Akka.Persistence.MongoDb.Query
             Sequence seq;
             switch (offset)
             {
+                case FromEnd fromEnd:
+                    return ResolveFromEnd(
+                        null,
+                        fromEnd.Count,
+                        sequence => Source.ActorPublisher<EventEnvelope>(
+                                AllEventsPublisher.Props(
+                                    sequence.Value,
+                                    null,
+                                    _maxBufferSize,
+                                    _writeJournalPluginId))
+                            .MapMaterializedValue(_ => NotUsed.Instance)
+                            .Named("CurrentAllEvents"));
                 case null:
                 case NoOffset _:
                     seq = new Sequence(0L);

--- a/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Query/MongoDbReadJournal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Journal;
@@ -63,6 +64,9 @@ namespace Akka.Persistence.MongoDb.Query
             var journalConfig = rootConfig.GetConfig(resolvedPluginId);
             var callTimeout = journalConfig?.GetTimeSpan("call-timeout", DefaultCallTimeout)
                               ?? DefaultCallTimeout;
+
+            if (callTimeout == Timeout.InfiniteTimeSpan)
+                return Timeout.InfiniteTimeSpan;
 
             // The journal cancels the MongoDB operation at call-timeout. Keep the Ask alive
             // long enough for that cancellation (or its result) to be piped back to the caller.

--- a/src/Akka.Persistence.MongoDb/Query/QueryApi.cs
+++ b/src/Akka.Persistence.MongoDb/Query/QueryApi.cs
@@ -173,6 +173,39 @@ namespace Akka.Persistence.MongoDb.Query
     }
 
     /// <summary>
+    /// Requests the exclusive ordering offset immediately before a last-N query window.
+    /// </summary>
+#nullable enable
+    [Serializable]
+    internal sealed class FindFromEndOffset : IJournalRequest
+    {
+        public FindFromEndOffset(string? tag, int count)
+        {
+            Tag = tag;
+            Count = count;
+        }
+
+        public string? Tag { get; }
+
+        public int Count { get; }
+    }
+
+    /// <summary>
+    /// Contains the concrete exclusive ordering offset for a last-N query window.
+    /// </summary>
+    [Serializable]
+    internal sealed class FromEndOffsetResult
+    {
+        public FromEndOffsetResult(long offset)
+        {
+            Offset = offset;
+        }
+
+        public long Offset { get; }
+    }
+#nullable restore
+
+    /// <summary>
     /// TBD
     /// </summary>
     [Serializable]


### PR DESCRIPTION
## Summary

- upgrade Akka.NET and Akka.Hosting dependencies to 1.5.70
- support Offset.FromEnd for current and live tag and all-events queries
- resolve the concrete MongoDB ordering anchor independently at source materialization time
- derive the journal Ask timeout from the selected journal call-timeout plus a small completion margin, while preserving infinite timeouts
- add transaction-on and transaction-off TCK coverage, concrete resumable Sequence offset assertions, and same-source rematerialization coverage

## Validation

- .NET 8 Release build
- FromEnd/configuration test suite: 25 passed across both transaction modes using MongoDB 8
- netstandard2.1 package produced with stable Akka.NET 1.5.70 dependencies

The full multi-target pack is locally limited by the missing .NET Framework 4.7.2 reference assembly; CI remains the authoritative multi-target validation.