### PR TITLE
chore: remove FluentAssertions ignore rule from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,3 @@ updates:
   - dependency-name: Akka.Persistence.Query
     versions:
     - 1.4.17
-  - dependency-name: FluentAssertions
-    versions:
-    - 5.10.3


### PR DESCRIPTION
FluentAssertions was removed from the repo in #465/#476, so the ignore rule pinning it to 5.10.3 is dead config. Removes it so dependabot.yml stays accurate.