### PR TITLE
fix: raise Windows test timeouts to deflake CI

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsLegacySerializationSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsLegacySerializationSnapshotStoreSpec.cs
@@ -33,7 +33,7 @@ public class MongoDbGridFsLegacySerializationSnapshotStoreSpec : SnapshotStoreSp
     private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
     {
         var specString = @"
-                akka.test.single-expect-default = 3s
+                akka.test.single-expect-default = 60s
                 akka.persistence {
                     publish-plugin-commands = on
                     snapshot-store {

--- a/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/GridFS/MongoDbGridFsSnapshotStoreSpec.cs
@@ -31,7 +31,7 @@ public class MongoDbGridFsSnapshotStoreSpec : SnapshotStoreSpec, IClassFixture<D
     private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
     {
         var specString = $$"""
-                           akka.test.single-expect-default = 3s
+                           akka.test.single-expect-default = 60s
                            akka.persistence {
                               publish-plugin-commands = on
                               snapshot-store {

--- a/src/Akka.Persistence.MongoDb.Tests/Hosting/EventAdapterRuntimeInvocationSpecs.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/Hosting/EventAdapterRuntimeInvocationSpecs.cs
@@ -139,9 +139,9 @@ public class EventAdapterRuntimeInvocationSpecs : Akka.Hosting.TestKit.TestKit, 
         var actor = Sys.ActorOf(Props.Create(() => new TestPersistentActor("test-1")));
 
         // Persist 3 events
-        await actor.Ask<string>(new TestPersistentActor.SaveEvent("event-1"), TimeSpan.FromSeconds(3));
-        await actor.Ask<string>(new TestPersistentActor.SaveEvent("event-2"), TimeSpan.FromSeconds(3));
-        await actor.Ask<string>(new TestPersistentActor.SaveEvent("event-3"), TimeSpan.FromSeconds(3));
+        await actor.Ask<string>(new TestPersistentActor.SaveEvent("event-1"), TimeSpan.FromSeconds(10));
+        await actor.Ask<string>(new TestPersistentActor.SaveEvent("event-2"), TimeSpan.FromSeconds(10));
+        await actor.Ask<string>(new TestPersistentActor.SaveEvent("event-3"), TimeSpan.FromSeconds(10));
 
         // CRITICAL: Use Persistence Query to verify events were tagged
         var queries = Sys.ReadJournalFor<MongoDbReadJournal>(MongoDbReadJournal.Identifier);
@@ -159,6 +159,6 @@ public class EventAdapterRuntimeInvocationSpecs : Akka.Hosting.TestKit.TestKit, 
 
             // Verify the events are the correct type
             Assert.True(taggedEvents.All(e => e.Event is TestEvent));
-        });
+        }, TimeSpan.FromSeconds(10));
     }
 }

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationSnapshotStoreSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbLegacySerializationSnapshotStoreSpec.cs
@@ -24,7 +24,7 @@ namespace Akka.Persistence.MongoDb.Tests
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture)
         {
             var specString = @"
-                akka.test.single-expect-default = 3s
+                akka.test.single-expect-default = 60s
                 akka.persistence {
                     publish-plugin-commands = on
                     snapshot-store {


### PR DESCRIPTION
Three Windows-only 3-second test timeouts this week — GridFS snapshot save, legacy serialization snapshot load, EventAdapter Ask — all the same root cause: test-side timeout budgets too tight for cold-start Mongo2Go writes on 2-vCPU Windows CI runners. See #449, #472, #479.

Changes:
- **GridFS specs** (MongoDbGridFsSnapshotStoreSpec + MongoDbGridFsLegacySerializationSnapshotStoreSpec): the CI-failing test is the inherited TCK `SnapshotStore_should_save_bigger_size_snapshot` (no `_consistently` suffix), which uses the TestKit default expect timeout (3s) for a 128MB GridFS write. Store-side call-timeout is already 60s. Raise `akka.test.single-expect-default` 3s → 60s to match.
- **MongoDbLegacySerializationSnapshotStoreSpec**: same 3s expect default for TCK snapshot load round-trips; raise to 60s.
- **EventAdapterRuntimeInvocationSpecs**: explicit `Ask(..., 3s)` on a cold-start journal write chain (recovery + auto-initialize index builds + insert) intermittently exceeds 3s on Windows. Raise to 10s (matches plugin call-timeout), and pass an explicit duration to `AwaitAssertAsync`.

A genuinely broken store still fails fast: store-side 60s circuit breaker / call-timeout emit `SaveSnapshotFailure`, which the `ExpectMsg<SaveSnapshotSuccess>` assertion rejects.

Verified: test project compiles clean (0 errors).