### PR TITLE
fix: raise query-spec timeouts and drop duplicate Ordering index

### DIFF
--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbCurrentPersistenceIdsSpec.cs
@@ -51,7 +51,7 @@ namespace Akka.Persistence.MongoDb.Tests
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id, bool transaction)
         {
             var specString = $$"""
-akka.test.single-expect-default = 3s
+akka.test.single-expect-default = 10s
 akka.persistence {
    publish-plugin-commands = on
    journal {

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByPersistenceIdSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbEventsByPersistenceIdSpec.cs
@@ -47,7 +47,7 @@ namespace Akka.Persistence.MongoDb.Tests
         {
 
             var specString = $$"""
-akka.test.single-expect-default = 3s
+akka.test.single-expect-default = 10s
 akka.persistence {
    publish-plugin-commands = on
    journal {

--- a/src/Akka.Persistence.MongoDb.Tests/MongoDbPersistenceIdsSpec.cs
+++ b/src/Akka.Persistence.MongoDb.Tests/MongoDbPersistenceIdsSpec.cs
@@ -58,7 +58,7 @@ namespace Akka.Persistence.MongoDb.Tests
         private static Config CreateSpecConfig(DatabaseFixture databaseFixture, int id, bool transaction)
         {
             var specString = $$"""
-akka.test.single-expect-default = 3s
+akka.test.single-expect-default = 10s
 akka.persistence {
    publish-plugin-commands = on
    journal {

--- a/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
+++ b/src/Akka.Persistence.MongoDb/Journal/MongoDbJournal.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MongoDbJournal.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
@@ -109,9 +109,6 @@ namespace Akka.Persistence.MongoDb.Journal
                 Builders<JournalEntry>
                     .IndexKeys
                     .Ascending(entry => entry.Ordering));
-
-            await _journalCollection_DoNotUseDirectly.Indexes
-                .CreateOneAsync(modelWithOrdering, cancellationToken: token);
 
             await _journalCollection_DoNotUseDirectly.Indexes
                 .CreateOneAsync(modelWithOrdering, cancellationToken: token);


### PR DESCRIPTION
Two Windows CI flakes this week (`MongoDbPersistenceIdsSpec` and `MongoDbEventsByPersistenceIdSpec`) are TCK `Setup()` write-ack timeouts. The TCK base tests write events through the journal and `ExpectMsg` the persist-callback ack within `akka.test.single-expect-default`, which these specs pinned at 3s. On a cold 2-vCPU Windows runner the first journal write (fresh Mongo2Go mongod + RS election + first index builds) can exceed 3s. Sibling plugins (Sql, Redis) run the same TCK at 10s.

Root cause analysis (from Azure DevOps build log 130113, saved locally): both stack traces terminate in `PersistenceIdsSpec.Setup` / `EventsByPersistenceIdSpec.Setup` → `ExpectMsg<String>` with the default timeout — the journal write ack, not the query. No exceptions, no hang; actor systems shut down cleanly. Purely a cold-start-write-exceeds-budget issue.

Changes:
- `MongoDbCurrentPersistenceIdsSpec`, `MongoDbEventsByPersistenceIdSpec`, `MongoDbPersistenceIdsSpec`: `single-expect-default` 3s → 10s (matches plugin call-timeout and the proven sibling baseline).
- `MongoDbJournal.GetJournalCollection`: remove the duplicated `CreateOneAsync(modelWithOrdering)` — the Ordering index was created twice, adding a redundant cold-start round-trip on every journal instance.

Verified: main library + test project compile clean. The derived-class `Setup` overrides can't deflake these (they hide the base method with CS0108 and are never invoked by the TCK base tests) — the config knob is the only mechanism that reaches them.